### PR TITLE
support initial priming file loaded on start-up

### DIFF
--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/Jzonbie.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/Jzonbie.java
@@ -141,6 +141,8 @@ public class Jzonbie implements JzonbieClient {
             httpsPort = null;
         }
 
+        options.getInitialPrimingFile().ifPresent(this::prime);
+
         LOGGER.info("Jzonbie started - HTTP port: {}{}", httpPort, httpsPort == null ? "" : ", HTTPS port: " + httpsPort);
     }
 

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/JzonbieOptions.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/JzonbieOptions.java
@@ -5,6 +5,7 @@ import com.jonnymatts.jzonbie.defaults.Priming;
 import com.jonnymatts.jzonbie.jackson.JzonbieObjectMapper;
 import com.jonnymatts.jzonbie.pippo.JzonbieRoute;
 
+import java.io.File;
 import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
@@ -61,6 +62,7 @@ public class JzonbieOptions {
     private HttpsOptions httpsOptions;
     private int callHistoryCapacity;
     private int failedRequestsCapacity;
+    private File initialPrimingFile;
 
     private JzonbieOptions() {
         this.httpPort = DEFAULT_PORT;
@@ -213,6 +215,18 @@ public class JzonbieOptions {
         return this;
     }
 
+    /**
+     * Specifies a JSON file containing priming that will be applied on Jzonbie start-up.
+     *
+     * @param initialPrimingFile the JSON priming file
+     * @return this Jzonbie configuration with initial priming file
+     * @see Jzonbie#prime(File)
+     */
+    public JzonbieOptions withInitialPrimingFile(File initialPrimingFile) {
+        this.initialPrimingFile = initialPrimingFile;
+        return this;
+    }
+
     public int getHttpPort() {
         return httpPort;
     }
@@ -245,5 +259,9 @@ public class JzonbieOptions {
 
     public int getFailedRequestsCapacity() {
         return failedRequestsCapacity;
+    }
+
+    public Optional<File> getInitialPrimingFile() {
+        return Optional.ofNullable(initialPrimingFile);
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/cli/CommandLineOptions.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/cli/CommandLineOptions.java
@@ -5,6 +5,8 @@ import com.jonnymatts.jzonbie.JzonbieOptions;
 import picocli.CommandLine;
 import picocli.CommandLine.Option;
 
+import java.io.File;
+
 import static com.jonnymatts.jzonbie.HttpsOptions.httpsOptions;
 import static com.jonnymatts.jzonbie.JzonbieOptions.options;
 
@@ -39,6 +41,9 @@ public class CommandLineOptions {
 
     @Option(names = {"--failed-requests-capacity"}, paramLabel = "SIZE", description = "maximum capacity of the stored failed requests")
     public Integer failedRequestsCapacity;
+
+    @Option(names = {"--initial-priming-file"}, paramLabel = "PATH", description = "path to initial priming file JSON")
+    public File initialPrimingFile;
 
     public static CommandLineOptions parse(String[] args) {
         final CommandLine cmd = new CommandLine(CommandLineOptions.class);
@@ -75,6 +80,9 @@ public class CommandLineOptions {
                 httpsOptions.withCommonName(commandLineOptions.commonName);
             }
             options.withHttps(httpsOptions);
+        }
+        if (commandLineOptions.initialPrimingFile != null) {
+            options.withInitialPrimingFile(commandLineOptions.initialPrimingFile);
         }
         return options;
     }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/cli/CommandLineOptionsTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/cli/CommandLineOptionsTest.java
@@ -5,7 +5,10 @@ import com.jonnymatts.jzonbie.JzonbieOptions;
 import org.junit.jupiter.api.Test;
 import picocli.CommandLine;
 
+import java.io.File;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CommandLineOptionsTest {
 
@@ -120,6 +123,12 @@ class CommandLineOptionsTest {
         final CommandLineOptions commandLineOptions = getCommandLineOptions("--failed-requests-capacity", "100");
 
         assertThat(commandLineOptions.failedRequestsCapacity).isEqualTo(100);
+    }
+
+    @Test
+    void initialPrimingFile() {
+        CommandLineOptions commandLineOptions = getCommandLineOptions("--initial-priming-file", "missing-file");
+        assertThat(commandLineOptions.initialPrimingFile).isEqualTo(new File("missing-file"));
     }
 
     @Test


### PR DESCRIPTION
It would be useful to initialise priming on start up on jzonbie, especially for stand-alone instances.