### PR TITLE
Fix count functionality and make count templatable

### DIFF
--- a/jzonbie-core/src/main/java/com/jonnymatts/jzonbie/Response.java
+++ b/jzonbie-core/src/main/java/com/jonnymatts/jzonbie/Response.java
@@ -4,13 +4,13 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
-public interface Response<T extends Body<?>> {
+public interface Response {
 
     int getStatusCode();
 
     Map<String, String> getHeaders();
 
-    T getBody();
+    Body<?> getBody();
 
     default Optional<Duration> getDelay() {
         return Optional.empty();

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/Jzonbie.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/Jzonbie.java
@@ -126,10 +126,10 @@ public class Jzonbie implements JzonbieClient {
         });
 
         final Handlebars handlebars = new JzonbieHandlebars();
-        final ResponseTransformer responseTransformer = new ResponseTransformer(handlebars);
-        final PippoResponder pippoResponder = new PippoResponder(responseTransformer, objectMapper);
+        final ResponseTransformer responseTransformer = new ResponseTransformer(objectMapper, handlebars);
+        final PippoResponder pippoResponder = new PippoResponder(objectMapper);
 
-        final PippoApplication application = new PippoApplication(options.getZombieHeaderName(), options.getRoutes(), appRequestHandler, zombieRequestHandler, pippoResponder);
+        final PippoApplication application = new PippoApplication(options.getZombieHeaderName(), options.getRoutes(), appRequestHandler, zombieRequestHandler, pippoResponder, responseTransformer);
 
         httpPippo = createPippo(application, options.getHttpPort());
         httpPippo.start();

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistory.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistory.java
@@ -2,14 +2,44 @@ package com.jonnymatts.jzonbie.history;
 
 import com.jonnymatts.jzonbie.requests.AppRequest;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-public class CallHistory extends FixedCapacityCache<Exchange> {
+
+public class CallHistory {
+
+    private final FixedCapacityCache<Exchange> exchangeCache;
+    private final Map<AppRequest, Integer> successfulRequestCounter;
 
     public CallHistory(int capacity) {
-        super(capacity);
+        exchangeCache = new FixedCapacityCache<>(capacity);
+        successfulRequestCounter = new ConcurrentHashMap<>();
+    }
+
+    public void add(AppRequest foundAppRequest, Exchange exchange) {
+        incrementCounter(foundAppRequest);
+        exchangeCache.add(exchange);
     }
 
     public int count(AppRequest appRequest) {
-        return (int)values.stream().filter(priming -> appRequest.matches(priming.getRequest())).count();
+        return successfulRequestCounter.getOrDefault(appRequest, 0);
+    }
+
+    public List<Exchange> getValues() {
+        return exchangeCache.getValues();
+    }
+
+    private void incrementCounter(AppRequest request) {
+            if(successfulRequestCounter.get(request) == null) {
+                successfulRequestCounter.put(request, 1);
+            } else {
+                successfulRequestCounter.compute(request, (request1, size) -> size + 1);
+            }
+    }
+
+    public void clear() {
+        successfulRequestCounter.clear();
+        exchangeCache.clear();
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/FixedCapacityCache.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/FixedCapacityCache.java
@@ -3,17 +3,17 @@ package com.jonnymatts.jzonbie.history;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class FixedCapacityCache<T> {
 
     private final int capacity;
-    final LinkedList<T> values;
+    private ConcurrentLinkedDeque<T> values;
 
     public FixedCapacityCache(int capacity) {
         this.capacity = capacity;
-        this.values = new LinkedList<>();
+        this.values = new ConcurrentLinkedDeque<>();
     }
 
     @JsonValue

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataContext.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataContext.java
@@ -1,27 +1,38 @@
-package com.jonnymatts.jzonbie.templating;
+package com.jonnymatts.jzonbie.metadata;
 
 import com.jonnymatts.jzonbie.pippo.PippoRequest;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
-public class TransformationContext {
+public class MetaDataContext {
 
-    public TransformationContext(PippoRequest request) {
+    private final RequestContext request;
+    private final Map<String, Object> processValues = new HashMap<>();
+
+    public MetaDataContext(PippoRequest request) {
         this(request.getProtocol(), request.getUrl(), request.getPort(),request.getPath(), request.getQueryParams(), request.getHeaders(), request.getMethod(), request.getBody());
     }
 
-    public TransformationContext(String protocol, String url, int port, String path, Map<String, List<String>> queryParams, Map<String, String> headers, String method, String body) {
+    public MetaDataContext(String protocol, String url, int port, String path, Map<String, List<String>> queryParams, Map<String, String> headers, String method, String body) {
         this.request = new RequestContext(protocol, url, port, path, queryParams, headers, method, body);
     }
 
-    public RequestContext request;
+    public Map<String, Object> getContext() {
+        Map<String, Object> context = new HashMap<>();
+        context.put("request", request);
+        context.putAll(processValues);
 
-    public RequestContext getRequest() {
-        return request;
+        return context;
+    }
+
+    public MetaDataContext withMetaData(MetaDataTag metaDataTag, Object value) {
+        processValues.put(metaDataTag.toString(), value);
+        return this;
     }
 
     public static class RequestContext {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataTag.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataTag.java
@@ -1,0 +1,6 @@
+package com.jonnymatts.jzonbie.metadata;
+
+public enum MetaDataTag {
+
+    ENDPOINT_REQUEST_COUNT
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoApplication.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoApplication.java
@@ -1,9 +1,12 @@
 package com.jonnymatts.jzonbie.pippo;
 
 import com.google.common.base.Stopwatch;
+import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.requests.AppRequestHandler;
 import com.jonnymatts.jzonbie.requests.RequestHandler;
 import com.jonnymatts.jzonbie.requests.ZombieRequestHandler;
+import com.jonnymatts.jzonbie.templating.ResponseTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -22,17 +25,20 @@ public class PippoApplication extends Application {
     private final AppRequestHandler appRequestHandler;
     private final ZombieRequestHandler zombieRequestHandler;
     private final PippoResponder pippoResponder;
+    private final ResponseTransformer responseTransformer;
 
     public PippoApplication(String zombieHeaderName,
                             List<JzonbieRoute> additionalRoutes,
                             AppRequestHandler appRequestHandler,
                             ZombieRequestHandler zombieRequestHandler,
-                            PippoResponder pippoResponder) {
+                            PippoResponder pippoResponder,
+                            ResponseTransformer responseTransformer) {
         this.zombieHeaderName = zombieHeaderName;
         this.additionalRoutes = additionalRoutes;
         this.appRequestHandler = appRequestHandler;
         this.zombieRequestHandler = zombieRequestHandler;
         this.pippoResponder = pippoResponder;
+        this.responseTransformer = responseTransformer;
     }
 
     @Override
@@ -50,10 +56,18 @@ public class PippoApplication extends Application {
 
         final RequestHandler requestHandler = zombieHeader != null ?
                 zombieRequestHandler : appRequestHandler;
-
-        pippoResponder.send(pippoResponse, pippoRequest, () -> requestHandler.handle(pippoRequest));
-
+        try {
+            pippoResponder.send(pippoResponse, getResponse(pippoRequest, requestHandler));
+        } catch (Exception e) {
+            pippoResponder.sendForException(pippoResponse, e);
+        }
         stopwatch.stop();
         LOGGER.debug("Handled request {} in {} ms", pippoRequest, stopwatch.elapsed(MILLISECONDS));
+    }
+
+    private Response getResponse(PippoRequest request, RequestHandler requestHandler) {
+        MetaDataContext context = new MetaDataContext(request);
+        Response response = requestHandler.handle(request, context);
+        return responseTransformer.transform(context, response);
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoRequest.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoRequest.java
@@ -28,15 +28,26 @@ public class PippoRequest implements Request {
     private final String primingFileContent;
 
     public PippoRequest(ro.pippo.core.Request request) {
-        protocol = request.getScheme();
-        url = request.getUrl();
-        port = request.getPort();
-        path = request.getPath();
-        method = request.getMethod();
-        headers = createHeaders(request);
-        body = request.getBody();
-        queryMap = createQueryMap(request);
-        primingFileContent = getPrimingFileContentFromRequest(request);
+        this(request.getScheme(),
+                request.getUrl(),
+                request.getPort(),
+                request.getPath(),
+                request.getMethod(),
+                createHeaders(request),
+                request.getBody(),
+                createQueryMap(request),
+                getPrimingFileContentFromRequest(request));
+    }
+    public PippoRequest(String protocol, String url, int port, String path, String method, Map<String, String> headers, String body, Map<String, List<String>> queryMap, String primingFileContent) {
+        this.protocol = protocol;
+        this.url = url;
+        this.port = port;
+        this.path = path;
+        this.method = method;
+        this.headers = headers;
+        this.body = body;
+        this.queryMap = queryMap;
+        this.primingFileContent = primingFileContent;
     }
 
     @Override
@@ -81,7 +92,7 @@ public class PippoRequest implements Request {
         return port;
     }
 
-    private Map<String,String> createHeaders(ro.pippo.core.Request request) {
+    private static Map<String, String> createHeaders(ro.pippo.core.Request request) {
         return list(request.getHttpServletRequest().getHeaderNames())
                 .stream()
                 .collect(
@@ -92,7 +103,7 @@ public class PippoRequest implements Request {
                 );
     }
 
-    private Map<String,List<String>> createQueryMap(ro.pippo.core.Request request) {
+    private static Map<String, List<String>> createQueryMap(ro.pippo.core.Request request) {
         return request.getQueryParameters().entrySet()
                 .stream()
                 .collect(
@@ -103,9 +114,10 @@ public class PippoRequest implements Request {
                 );
     }
 
-    private String getPrimingFileContentFromRequest(ro.pippo.core.Request request) {
+    private static String getPrimingFileContentFromRequest(ro.pippo.core.Request request) {
         final String contentType = request.getContentType();
-        if(contentType == null || !contentType.startsWith(FILE_CONTENT_TYPE) || request.getFiles().isEmpty()) return null;
+        if (contentType == null || !contentType.startsWith(FILE_CONTENT_TYPE) || request.getFiles().isEmpty())
+            return null;
         return of(request.getFile("priming"))
                 .map(fileItem -> {
                     try {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoResponder.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoResponder.java
@@ -5,19 +5,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jonnymatts.jzonbie.Body;
 import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.body.LiteralBodyContent;
+import com.jonnymatts.jzonbie.requests.AppRequest;
 import com.jonnymatts.jzonbie.requests.PrimingNotFoundException;
 import com.jonnymatts.jzonbie.responses.CurrentPrimingFileResponseFactory.FileResponse;
 import com.jonnymatts.jzonbie.responses.ErrorResponse;
 import com.jonnymatts.jzonbie.responses.PrimingNotFoundErrorResponse;
-import com.jonnymatts.jzonbie.templating.ResponseTransformer;
-import com.jonnymatts.jzonbie.templating.TransformationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
@@ -28,41 +26,37 @@ public class PippoResponder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PippoApplication.class);
 
-    private final ResponseTransformer responseTransformer;
     private final ObjectMapper objectMapper;
 
-    public PippoResponder(ResponseTransformer responseTransformer, ObjectMapper objectMapper) {
-        this.responseTransformer = responseTransformer;
+    public PippoResponder(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public void send(ro.pippo.core.Response pippoResponse, PippoRequest pippoRequest, Supplier<Response<?>> responseSupplier) {
+    public void send(ro.pippo.core.Response pippoResponse, Response response) {
         try {
-            final Response<?> response = responseSupplier.get();
             if(response instanceof FileResponse) {
                 final FileResponse fileResponse = (FileResponse) response;
                 pippoResponse.contentType(APPLICATION_JSON);
                 pippoResponse.file(fileResponse.getFileName(), new ByteArrayInputStream(fileResponse.getContents().getBytes()));
-            } else if(response.isTemplated()) {
-                final TransformationContext transformationContext = new TransformationContext(pippoRequest);
-                final Map<String, String> transformedHeaders = responseTransformer.transformHeaders(transformationContext, response.getHeaders());
-                primeResponse(pippoResponse, response.getStatusCode(), transformedHeaders);
-                sleepIfNecessary(response);
-                final String bodyString = getBodyString(response.getBody());
-                final String transformedBodyString = responseTransformer.transformBody(transformationContext, bodyString);
-                send(pippoResponse, transformedBodyString);
             } else {
                 primeResponse(pippoResponse, response.getStatusCode(), response.getHeaders());
                 sleepIfNecessary(response);
                 final String bodyString = getBodyString(response.getBody());
                 send(pippoResponse, bodyString);
             }
-        } catch (PrimingNotFoundException e) {
-            LOGGER.error("Priming not found for request {}", e.getRequest());
-            sendErrorResponse(pippoResponse, SC_NOT_FOUND, new PrimingNotFoundErrorResponse(e.getRequest()));
         } catch (Exception e) {
+            sendForException(pippoResponse, e);
+        }
+    }
+
+    public void sendForException(ro.pippo.core.Response response, Exception e) {
+        if(e.getClass().equals(PrimingNotFoundException.class)) {
+            AppRequest request = ((PrimingNotFoundException)e).getRequest();
+            LOGGER.error("Priming not found for request {}", request);
+            sendErrorResponse(response, SC_NOT_FOUND, new PrimingNotFoundErrorResponse(request));
+        } else {
             LOGGER.error("Exception occurred: " + e.getClass().getSimpleName(), e);
-            sendErrorResponse(pippoResponse, SC_INTERNAL_SERVER_ERROR, new ErrorResponse(format("Error occurred: %s - %s", e.getClass().getName(), e.getMessage())));
+            sendErrorResponse(response, SC_INTERNAL_SERVER_ERROR, new ErrorResponse(format("Error occurred: %s - %s", e.getClass().getName(), e.getMessage())));
         }
     }
 
@@ -74,7 +68,7 @@ public class PippoResponder {
         }
     }
 
-    private void sleepIfNecessary(Response<?> response) {
+    private void sleepIfNecessary(Response response) {
         response.getDelay().ifPresent(d -> {
             try {
                 Thread.sleep(d.toMillis());

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/priming/PrimingContext.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/priming/PrimingContext.java
@@ -1,6 +1,5 @@
 package com.jonnymatts.jzonbie.priming;
 
-import com.jonnymatts.jzonbie.Body;
 import com.jonnymatts.jzonbie.defaults.DefaultResponsePriming;
 import com.jonnymatts.jzonbie.defaults.Priming;
 import com.jonnymatts.jzonbie.defaults.StandardPriming;
@@ -9,20 +8,22 @@ import com.jonnymatts.jzonbie.responses.AppResponse;
 import com.jonnymatts.jzonbie.responses.defaults.DefaultAppResponse;
 import com.jonnymatts.jzonbie.responses.defaults.DefaultingQueue;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
-import static java.util.Optional.of;
 
 public class PrimingContext {
     private final List<Priming> priming;
-    private Map<HeaderlessAppRequest, Map<AppRequest, DefaultingQueue>> primedMappings;
+    private Map<AppRequest, DefaultingQueue> primedMappings;
 
     public PrimingContext(List<Priming> priming) {
         this.priming = priming;
-        this.primedMappings = new HashMap<>();
+        this.primedMappings = new ConcurrentHashMap<>();
         addDefaultPriming();
     }
 
@@ -30,8 +31,8 @@ public class PrimingContext {
         this(emptyList());
     }
 
-    synchronized public List<PrimedMapping> getCurrentPriming() {
-        return primedMappings.entrySet().stream().map(e -> e.getValue().entrySet()).flatMap(Collection::stream)
+    public List<PrimedMapping> getCurrentPriming() {
+        return primedMappings.entrySet().stream()
                 .map(e -> new PrimedMapping(e.getKey(), e.getValue()))
                 .collect(Collectors.toList());
     }
@@ -40,79 +41,49 @@ public class PrimingContext {
         return add(zombiePriming.getRequest(), zombiePriming.getResponse());
     }
 
-    synchronized public PrimingContext add(AppRequest appRequest, AppResponse appResponse) {
-        final DefaultingQueue responseQueue = getAppResponseQueueForAdd(appRequest);
-
-        responseQueue.add(appResponse);
+    public PrimingContext add(AppRequest appRequest, AppResponse appResponse) {
+        getAppResponseQueueForAdd(appRequest).add(appResponse);
 
         return this;
     }
 
-    synchronized public PrimingContext addDefault(AppRequest appRequest, DefaultAppResponse defaultAppResponse) {
-        final DefaultingQueue responseQueue = getAppResponseQueueForAdd(appRequest);
-
-        responseQueue.setDefault(defaultAppResponse);
+    public PrimingContext addDefault(AppRequest appRequest, DefaultAppResponse defaultAppResponse) {
+        getAppResponseQueueForAdd(appRequest).setDefault(defaultAppResponse);
 
         return this;
     }
 
-    private DefaultingQueue getAppResponseQueueForAdd(AppRequest appRequest) {
-        final HeaderlessAppRequest headerlessAppRequest = new HeaderlessAppRequest(appRequest);
-        Map<AppRequest, DefaultingQueue> mappingsForHeaderlessRequest = primedMappings
-                .computeIfAbsent(headerlessAppRequest, k -> new HashMap<>());
-
-        DefaultingQueue responseQueue = mappingsForHeaderlessRequest.get(appRequest);
-
-        if(responseQueue == null) {
-            responseQueue = new DefaultingQueue();
-            mappingsForHeaderlessRequest.put(appRequest, responseQueue);
-        }
-
-        return responseQueue;
+    public Optional<AppRequest> getPrimedRequest(AppRequest appRequest) {
+        return primedMappings.entrySet().parallelStream()
+                .filter(priming -> priming.getKey().matches(appRequest))
+                .map(Map.Entry::getKey)
+                .findFirst();
     }
 
-    synchronized public Optional<AppResponse> getResponse(AppRequest appRequest) {
-        final HeaderlessAppRequest headerlessAppRequest = new HeaderlessAppRequest(appRequest);
-        final Optional<MapAppRequestAndQueue> mapAppRequestAndQueue = findMapAndQueue(appRequest);
+    public Optional<AppResponse> getResponse(AppRequest appRequest) {
+        final DefaultingQueue primedResponsesQueue = primedMappings.get(appRequest);
 
-        if (!mapAppRequestAndQueue.isPresent())
+        if (primedResponsesQueue == null) {
             return empty();
+        }
 
-        return mapAppRequestAndQueue.map(m -> {
-            final DefaultingQueue responseQueue = m.getQueue();
-            final Map<AppRequest, DefaultingQueue> mapping = m.getMap();
+        final AppResponse appResponse = primedResponsesQueue.poll();
 
-            final AppResponse appResponse = responseQueue.poll();
+        if (primedResponsesQueue.hasSize() == 0 && !primedResponsesQueue.getDefault().isPresent()) {
+            primedMappings.remove(appRequest);
+        }
 
-            if(responseQueue.hasSize() == 0 && !responseQueue.getDefault().isPresent())
-                mapping.remove(m.getAppRequest());
-
-            if(mapping.isEmpty())
-                primedMappings.remove(headerlessAppRequest);
-            return appResponse;
-        });
+        return Optional.ofNullable(appResponse);
     }
 
-    private Optional<MapAppRequestAndQueue> findMapAndQueue(AppRequest appRequest) {
-        final HeaderlessAppRequest headerlessAppRequest = new HeaderlessAppRequest(appRequest);
-        Map<AppRequest, DefaultingQueue> map = primedMappings.get(headerlessAppRequest);
-        if(map == null) {
-            for (Map<AppRequest, DefaultingQueue> e : primedMappings.values()) {
-                final Optional<Map.Entry<AppRequest, DefaultingQueue>> entryOpt = findResponseQueueFromMapForRequest(e, appRequest);
-                if(entryOpt.isPresent()) {
-                    final Map.Entry<AppRequest, DefaultingQueue> entry = entryOpt.get();
-                    return of(new MapAppRequestAndQueue(e, entry.getKey(), entry.getValue()));
-                }
-            }
-        } else {
-            return findResponseQueueFromMapForRequest(map, appRequest).map(q -> new MapAppRequestAndQueue(map, q.getKey(), q.getValue()));
-        }
-        return empty();
+    public void reset() {
+        primedMappings.clear();
+        addDefaultPriming();
     }
 
     private void addDefaultPriming() {
         for (Priming priming : priming) {
-            if(priming instanceof StandardPriming) {
+            if (priming instanceof StandardPriming) {
                 final StandardPriming defaultPriming = (StandardPriming) priming;
                 add(defaultPriming.getRequest(), defaultPriming.getResponse());
             } else {
@@ -122,75 +93,12 @@ public class PrimingContext {
         }
     }
 
-    private static class MapAppRequestAndQueue {
-        private final Map<AppRequest, DefaultingQueue> map;
-        private final AppRequest appRequest;
-        private final DefaultingQueue queue;
-
-        public MapAppRequestAndQueue(Map<AppRequest, DefaultingQueue> map, AppRequest appRequest, DefaultingQueue queue) {
-            this.map = map;
-            this.appRequest = appRequest;
-            this.queue = queue;
-        }
-
-        public Map<AppRequest, DefaultingQueue> getMap() {
-            return map;
-        }
-
-        public AppRequest getAppRequest() {
-            return appRequest;
-        }
-
-        public DefaultingQueue getQueue() {
-            return queue;
-        }
-    }
-
-    private Optional<Map.Entry<AppRequest, DefaultingQueue>> findResponseQueueFromMapForRequest(Map<AppRequest, DefaultingQueue> map, AppRequest appRequest) {
-        return map.entrySet().parallelStream()
-                .filter(priming -> priming.getKey().matches(appRequest))
-                .findFirst();
-    }
-
-    synchronized public void reset() {
-        primedMappings.clear();
-        addDefaultPriming();
-    }
-
-    private static class HeaderlessAppRequest {
-        private final String path;
-        private final String method;
-        private final Body<?> body;
-        private final Map<String, List<String>> queryParams;
-
-        private HeaderlessAppRequest(AppRequest appRequest) {
-            this.path = appRequest.getPath();
-            this.method = appRequest.getMethod();
-            this.body = appRequest.getBody();
-            this.queryParams = appRequest.getQueryParams();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if(this == o) return true;
-            if(o == null || getClass() != o.getClass()) return false;
-
-            HeaderlessAppRequest that = (HeaderlessAppRequest) o;
-
-            if(path != null ? !path.equals(that.path) : that.path != null) return false;
-            if(method != null ? !method.equals(that.method) : that.method != null) return false;
-            if(body != null ? !body.getContent().equals(that.body.getContent()) : that.body != null) return false;
-            return queryParams != null ? queryParams.equals(that.queryParams) : that.queryParams == null;
-
-        }
-
-        @Override
-        public int hashCode() {
-            int result = path != null ? path.hashCode() : 0;
-            result = 31 * result + (method != null ? method.hashCode() : 0);
-            result = 31 * result + (body != null ? body.getContent().hashCode() : 0);
-            result = 31 * result + (queryParams != null ? queryParams.hashCode() : 0);
-            return result;
+    private DefaultingQueue getAppResponseQueueForAdd(AppRequest appRequest) {
+        if (primedMappings.get(appRequest) == null) {
+            primedMappings.put(appRequest, new DefaultingQueue());
+            return primedMappings.get(appRequest);
+        } else {
+            return primedMappings.get(appRequest);
         }
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/AppRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/AppRequestHandler.java
@@ -46,7 +46,7 @@ public class AppRequestHandler implements RequestHandler {
 
             final AppResponse zombieResponse = primedResponseOpt.get();
 
-        callHistory.add(new Exchange(appRequest, zombieResponse));
+        callHistory.add(primedRequest, new Exchange(appRequest, zombieResponse));
 
             return zombieResponse;
         } else {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/RequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/RequestHandler.java
@@ -2,8 +2,9 @@ package com.jonnymatts.jzonbie.requests;
 
 import com.jonnymatts.jzonbie.Request;
 import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 
 public interface RequestHandler {
 
-    Response handle(Request request);
+    Response handle(Request request, MetaDataContext metaDataContext);
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
@@ -5,6 +5,7 @@ import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.history.CallHistory;
 import com.jonnymatts.jzonbie.history.FixedCapacityCache;
 import com.jonnymatts.jzonbie.jackson.Deserializer;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.priming.PrimedMapping;
 import com.jonnymatts.jzonbie.priming.PrimingContext;
 import com.jonnymatts.jzonbie.priming.ZombiePriming;
@@ -51,7 +52,7 @@ public class ZombieRequestHandler implements RequestHandler {
     }
 
     @Override
-    public Response handle(Request request) {
+    public Response handle(Request request, MetaDataContext metaDataContext) {
         final String zombieHeaderValue = request.getHeaders().get(zombieHeaderName);
 
         switch(zombieHeaderValue) {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
@@ -115,7 +115,7 @@ public class ZombieRequestHandler implements RequestHandler {
     }
 
     private ZombieResponse handleHistoryRequest() {
-        return new ZombieResponse(OK_200, callHistory);
+        return new ZombieResponse(OK_200, callHistory.getValues());
     }
 
     private ZombieResponse handleFailedRequest() {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/templating/ResponseTransformer.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/templating/ResponseTransformer.java
@@ -1,7 +1,14 @@
 package com.jonnymatts.jzonbie.templating;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.jonnymatts.jzonbie.Body;
+import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.body.LiteralBodyContent;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
+import com.jonnymatts.jzonbie.responses.AppResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,33 +16,66 @@ import java.util.Map;
 import static java.lang.String.format;
 
 public class ResponseTransformer {
+    private final ObjectMapper objectMapper;
     private final Handlebars handlebars;
 
-    public ResponseTransformer(Handlebars handlebars) {
+    public ResponseTransformer(ObjectMapper objectMapper, Handlebars handlebars) {
+        this.objectMapper = objectMapper;
         this.handlebars = handlebars;
     }
 
-    public Map<String, String> transformHeaders(TransformationContext transformationContext, Map<String, String> headers) {
-        if(headers == null) return null;
+    public Response transform(MetaDataContext metaDataContext, Response appResponse) {
+        try {
+            if (appResponse.isTemplated()) {
+                Map<String, String> responseHeaders = appResponse.getHeaders();
+                final Map<String, String> transformedHeaders = transformHeaders(metaDataContext, responseHeaders);
+                final String transformedBody = transformBody(metaDataContext, getBodyString(appResponse.getBody()));
+                return buildNewResponse(appResponse.getStatusCode(), transformedHeaders, transformedBody);
+            } else {
+                return appResponse;
+            }
+        } catch(TransformResponseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TransformResponseException(e);
+        }
+    }
+
+    private Map<String, String> transformHeaders(MetaDataContext metaDataContext, Map<String, String> headers) {
+        if (headers == null) return null;
         final Map<String, String> transformedHeaders = new HashMap<>();
 
-        for(Map.Entry<String, String> header : headers.entrySet()) {
-            final String transformedValue = transformValue(transformationContext, header.getValue());
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            final String transformedValue = transformValue(metaDataContext, header.getValue());
             transformedHeaders.put(header.getKey(), transformedValue);
         }
         return transformedHeaders;
     }
 
-    public String transformBody(TransformationContext transformationContext, String bodyString) {
-        return transformValue(transformationContext, bodyString);
+    private String transformBody(MetaDataContext metaDataContext, String bodyString) {
+        return transformValue(metaDataContext, bodyString);
     }
 
-    private String transformValue(TransformationContext transformationContext, String value) {
+    private String transformValue(MetaDataContext metaDataContext, String value) {
         try {
             final Template template = handlebars.compileInline(value);
-            return template.apply(transformationContext);
+           return template.apply(metaDataContext.getContext());
         } catch (Exception e) {
             throw new TransformResponseException(format("Could not transform: %s", value), e);
         }
     }
+
+    private Response buildNewResponse(int statusCode, Map<String, String> newHeaders, String transformedBody) {
+        final AppResponse response = new AppResponse(statusCode);
+        response.setHeaders(newHeaders);
+        response.withBody(transformedBody);
+        return response;
+    }
+
+    private String getBodyString(Body<?> body) throws JsonProcessingException {
+        if (body == null) return null;
+        if (body instanceof LiteralBodyContent) return ((LiteralBodyContent) body).getContent();
+        return objectMapper.writeValueAsString(body.getContent());
+    }
+
 }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/CallHistoryTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/CallHistoryTest.java
@@ -1,6 +1,7 @@
 package com.jonnymatts.jzonbie.history;
 
 
+import com.jonnymatts.jzonbie.requests.AppRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CallHistoryTest {
 
+    private final AppRequest primedRequest = get("1");
     private final Exchange exchange1 = new Exchange(get("1"), ok());
 
     private CallHistory underTest;
@@ -21,11 +23,24 @@ class CallHistoryTest {
 
     @Test
     void countReturnsRequestCountOfMatchingRequestWhenHistoryHasASingleRequest() throws Exception {
-        underTest.add(exchange1);
+        underTest.add(primedRequest, exchange1);
 
         final int got = underTest.count(exchange1.getRequest());
 
         assertThat(got).isEqualTo(1);
+    }
+
+    @Test
+    void countIsNotAffectedBySizeOfHistoryCache() throws Exception {
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+
+        final int got = underTest.count(exchange1.getRequest());
+
+        assertThat(got).isEqualTo(5);
     }
 
     @Test

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/pippo/PippoApplicationTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/pippo/PippoApplicationTest.java
@@ -204,7 +204,7 @@ class PippoApplicationTest {
 
     @Test
     void testHistory() throws Exception {
-        callHistory.add(exchange);
+        callHistory.add(appRequest, exchange);
 
         final Response pippoResponse = given()
                 .header("zombie", "history")
@@ -233,7 +233,7 @@ class PippoApplicationTest {
     @Test
     void testReset() throws Exception {
         primingContext.add(zombiePriming);
-        callHistory.add(exchange);
+        callHistory.add(appRequest, exchange);
         failedRequests.add(appRequest);
 
         final Response pippoResponse = given()
@@ -367,7 +367,7 @@ class PippoApplicationTest {
                 .withBody(objectBody(singletonMap("key", "val")));
         final AppResponse appResponse = ok();
 
-        callHistory.add(new Exchange(appRequest, appResponse));
+        callHistory.add(appRequest, new Exchange(appRequest, appResponse));
 
         final Response pippoResponse = given()
                 .header("zombie", "count")

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/priming/PrimingContextTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/priming/PrimingContextTest.java
@@ -188,8 +188,8 @@ class PrimingContextTest {
         primingContext.add(zombiePriming);
 
         final AppRequest copy = new AppRequest(zombiePriming.getRequest()).withHeader("extra", "header");
-
-        primingContext.getResponse(copy);
+        AppRequest foundAppRequest = primingContext.getPrimedRequest(copy).get();
+        primingContext.getResponse(foundAppRequest);
 
         final List<PrimedMapping> currentPriming = primingContext.getCurrentPriming();
 

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
@@ -6,6 +6,7 @@ import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.history.CallHistory;
 import com.jonnymatts.jzonbie.history.Exchange;
 import com.jonnymatts.jzonbie.history.FixedCapacityCache;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.priming.AppRequestFactory;
 import com.jonnymatts.jzonbie.priming.PrimingContext;
 import com.jonnymatts.jzonbie.priming.ZombiePriming;
@@ -32,6 +33,7 @@ class AppRequestHandlerTest {
     @Mock private FixedCapacityCache<AppRequest> failedRequests;
     @Mock private AppRequestFactory appRequestFactory;
     @Mock private Request request;
+    @Mock private MetaDataContext metaDataContext;
 
     private ZombiePriming zombiePriming;
     private Exchange exchange;
@@ -60,7 +62,7 @@ class AppRequestHandlerTest {
         when(primingContext.getPrimedRequest(appRequest)).thenReturn(of(appRequest));
         when(primingContext.getResponse(appRequest))
                 .thenReturn(of(appResponse));
-        final Response got = appRequestHandler.handle(request);
+        final Response got = appRequestHandler.handle(request, metaDataContext);
 
         assertThat(got).isEqualTo(appResponse);
     }
@@ -70,14 +72,14 @@ class AppRequestHandlerTest {
         when(primingContext.getPrimedRequest(appRequest)).thenReturn(of(appRequest));
         when(primingContext.getResponse(appRequest))
                 .thenReturn(of(appResponse));
-        appRequestHandler.handle(request);
+        appRequestHandler.handle(request, metaDataContext);
 
         verify(callHistory).add(appRequest, exchange);
     }
 
     @Test
     void handleThrowsPrimingNotFoundExceptionIfPrimingIsNotFound() throws Exception {
-        assertThatThrownBy(() -> appRequestHandler.handle(request))
+        assertThatThrownBy(() -> appRequestHandler.handle(request, metaDataContext))
                 .isExactlyInstanceOf(PrimingNotFoundException.class)
                 .hasFieldOrPropertyWithValue("request", appRequest);
     }
@@ -85,7 +87,7 @@ class AppRequestHandlerTest {
     @Test
     void handleAddsRequestToFailedRequestsIfPrimingIsNotFound() throws Exception {
         try{
-            appRequestHandler.handle(request);
+            appRequestHandler.handle(request, metaDataContext);
         } catch (Exception e) {
             verify(failedRequests).add(appRequest);
         }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
@@ -72,7 +72,7 @@ class AppRequestHandlerTest {
                 .thenReturn(of(appResponse));
         appRequestHandler.handle(request);
 
-        verify(callHistory).add(exchange);
+        verify(callHistory).add(appRequest, exchange);
     }
 
     @Test

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandlerTest.java
@@ -97,9 +97,9 @@ class ZombieRequestHandlerTest {
         exchange3 = new Exchange(request3, response);
 
         callHistory = new CallHistory(100);
-        callHistory.add(exchange1);
-        callHistory.add(exchange2);
-        callHistory.add(exchange3);
+        callHistory.add(request1, exchange1);
+        callHistory.add(request2, exchange2);
+        callHistory.add(request3, exchange3);
 
         failedRequests = new FixedCapacityCache<>(100);
         failedRequests.add(appRequests.get(0));
@@ -219,7 +219,7 @@ class ZombieRequestHandlerTest {
 
         final Response got = zombieRequestHandler.handle(request);
 
-        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory));
+        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory.getValues()));
     }
 
     @Test
@@ -258,7 +258,7 @@ class ZombieRequestHandlerTest {
 
         final Response got = zombieRequestHandler.handle(request);
 
-        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory));
+        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory.getValues()));
     }
 
     @Test

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/templating/ResponseTransformerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/templating/ResponseTransformerTest.java
@@ -1,14 +1,16 @@
 package com.jonnymatts.jzonbie.templating;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.jackson.JzonbieObjectMapper;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
+import com.jonnymatts.jzonbie.responses.AppResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
-
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.lenient;
@@ -16,43 +18,63 @@ import static org.mockito.Mockito.lenient;
 @ExtendWith(MockitoExtension.class)
 class ResponseTransformerTest {
 
-    @Mock(answer = RETURNS_DEEP_STUBS) private TransformationContext transformationContext;
+    @Mock(answer = RETURNS_DEEP_STUBS) private MetaDataContext metaDataContext;
+    @Mock private MetaDataContext.RequestContext requestContext;
 
     private ResponseTransformer underTest;
 
     @BeforeEach
     void setUp() throws Exception {
-        lenient().when(transformationContext.getRequest().getUrl()).thenReturn("url");
-        lenient().when(transformationContext.getRequest().getMethod()).thenReturn("method");
+        lenient().when(metaDataContext.getContext().get("request")).thenReturn(requestContext);
+        lenient().when(requestContext.getMethod()).thenReturn("method");
+        lenient().when(requestContext.getUrl()).thenReturn("url");
 
-        underTest = new ResponseTransformer(new JzonbieHandlebars());
+        underTest = new ResponseTransformer(new JzonbieObjectMapper(), new JzonbieHandlebars());
     }
 
     @Test
-    void transformHeadersReturnsTransformedBody() {
-        final Map<String, String> got = underTest.transformHeaders(transformationContext, singletonMap("header", "{{ request.method }}"));
+    void doNothingIfNotTemplated() throws JsonProcessingException {
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.withHeader("header", "{{ request.method }}");
+        appResponse.withBody("");
+        Response got = underTest.transform(metaDataContext, appResponse);
+        assertThat(got.getHeaders()).containsExactly(entry("header", "{{ request.method }}"));
+    }
 
-        assertThat(got).containsExactly(
-                entry("header", "method")
-        );
+    @Test
+    void templatedHeadersReturnsTransformedHeaders() throws JsonProcessingException {
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.withHeader("header", "{{ request.method }}");
+        appResponse.withBody("");
+        appResponse.templated();
+        Response got = underTest.transform(metaDataContext, appResponse);
+        assertThat(got.getHeaders()).containsExactly(entry("header", "method"));
     }
 
     @Test
     void transformHeadersThrowsExceptionIfHandlebarsThrowsException() {
-        assertThatThrownBy(() -> underTest.transformHeaders(transformationContext, singletonMap("header", null)))
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.templated();
+        appResponse.withHeader("header", null);
+        assertThatThrownBy(() -> underTest.transform(metaDataContext, appResponse))
                 .isInstanceOf(TransformResponseException.class);
     }
 
     @Test
-    void transformBodyReturnsTransformedBody() {
-        final String got = underTest.transformBody(transformationContext, "{{ request.url }}");
+    void transformBodyReturnsTransformedBody() throws JsonProcessingException {
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.templated();
+        appResponse.withBody("{{ request.url }}");
+        final Response got = underTest.transform(metaDataContext, appResponse);
 
-        assertThat(got).isEqualTo("url");
+        assertThat(((String)got.getBody().getContent())).isEqualTo("url");
     }
 
     @Test
     void transformBodyThrowsExceptionIfHandlebarsThrowsException() {
-        assertThatThrownBy(() -> underTest.transformBody(transformationContext, null))
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.templated();
+        assertThatThrownBy(() -> underTest.transform(metaDataContext, appResponse))
                 .isInstanceOf(TransformResponseException.class);
     }
 }


### PR DESCRIPTION
- Split out priming context a bit to give more seperation of concerns.
- Fixed count to no longer rely on the size of the internal list, so there is no longer an upper limit on the count number
- Made this count templatable via MetaDataTag ENDPOINT_REQUEST_COUNT