### PR TITLE
Added home folder for jzonbie and added persistent count of api requests

### DIFF
--- a/jzonbie-client/src/main/java/com/jonnymatts/jzonbie/client/ApacheJzonbieHttpClient.java
+++ b/jzonbie-client/src/main/java/com/jonnymatts/jzonbie/client/ApacheJzonbieHttpClient.java
@@ -211,6 +211,22 @@ public class ApacheJzonbieHttpClient implements JzonbieClient {
         );
     }
 
+    @Override
+    public int getCount(AppRequest request) {
+        final HttpUriRequest countRequest = apacheJzonbieRequestFactory.createCountRequest(request);
+
+        return execute(countRequest, httpResponse -> deserializer.deserialize(getHttpResponseBody(httpResponse), CountResult.class), "Could not get request count")
+                .getCount();
+    }
+
+    @Override
+    public int getPersistentCount(AppRequest request) {
+        final HttpUriRequest countRequest = apacheJzonbieRequestFactory.createPersistentCountRequest(request);
+
+        return execute(countRequest, httpResponse -> deserializer.deserialize(getHttpResponseBody(httpResponse), CountResult.class), "Could not get persistent request count")
+                .getCount();
+    }
+
     /**
      * Checks whether the Jzonbie is ready to serve traffic.
      *

--- a/jzonbie-client/src/main/java/com/jonnymatts/jzonbie/client/ApacheJzonbieRequestFactory.java
+++ b/jzonbie-client/src/main/java/com/jonnymatts/jzonbie/client/ApacheJzonbieRequestFactory.java
@@ -103,6 +103,14 @@ public class ApacheJzonbieRequestFactory {
                 .build();
     }
 
+    public HttpUriRequest createCountRequest(AppRequest appRequest) {
+        return createPostRequest(appRequest, "count");
+    }
+
+    public HttpUriRequest createPersistentCountRequest(AppRequest appRequest) {
+        return createPostRequest(appRequest, "persistent-count");
+    }
+
     private HttpUriRequest createPostRequest(Object requestBody, String zombieHeader) {
         try {
             return RequestBuilder.post(zombieBaseUrl)

--- a/jzonbie-core/src/main/java/com/jonnymatts/jzonbie/JzonbieClient.java
+++ b/jzonbie-core/src/main/java/com/jonnymatts/jzonbie/JzonbieClient.java
@@ -118,4 +118,8 @@ public interface JzonbieClient {
      * @return truststore containing generated public key
      */
     KeyStore getTruststore();
+
+    int getCount(AppRequest request);
+
+    int getPersistentCount(AppRequest request);
 }

--- a/jzonbie-core/src/main/java/com/jonnymatts/jzonbie/Response.java
+++ b/jzonbie-core/src/main/java/com/jonnymatts/jzonbie/Response.java
@@ -4,13 +4,13 @@ import java.time.Duration;
 import java.util.Map;
 import java.util.Optional;
 
-public interface Response<T extends Body<?>> {
+public interface Response {
 
     int getStatusCode();
 
     Map<String, String> getHeaders();
 
-    T getBody();
+    Body<?> getBody();
 
     default Optional<Duration> getDelay() {
         return Optional.empty();

--- a/jzonbie-junit4/src/main/java/com/jonnymatts/jzonbie/junit/JzonbieRule.java
+++ b/jzonbie-junit4/src/main/java/com/jonnymatts/jzonbie/junit/JzonbieRule.java
@@ -78,7 +78,7 @@ public class JzonbieRule<T extends Jzonbie> extends ExternalResource implements 
      * @return default Jzonbie rule
      */
     public static JzonbieRule<Jzonbie> jzonbie(JzonbieOptions options) {
-        return new JzonbieRule<>(() -> new Jzonbie(options));
+        return new JzonbieRule<>(() -> new TestJzonbie(options));
     }
 
     /**
@@ -155,6 +155,16 @@ public class JzonbieRule<T extends Jzonbie> extends ExternalResource implements 
     @Override
     public KeyStore getTruststore() {
         return jzonbie.getTruststore();
+    }
+
+    @Override
+    public int getCount(AppRequest request) {
+        return jzonbie.getCount(request);
+    }
+
+    @Override
+    public int getPersistentCount(AppRequest request) {
+        return jzonbie.getPersistentCount(request);
     }
 
     /**

--- a/jzonbie-junit4/src/test/java/com/jonnymatts/jzonbie/junit/CustomJzonbie.java
+++ b/jzonbie-junit4/src/test/java/com/jonnymatts/jzonbie/junit/CustomJzonbie.java
@@ -1,6 +1,7 @@
 package com.jonnymatts.jzonbie.junit;
 
 import com.jonnymatts.jzonbie.Jzonbie;
+import org.assertj.core.util.Files;
 
 import static com.jonnymatts.jzonbie.JzonbieOptions.options;
 import static com.jonnymatts.jzonbie.defaults.StandardPriming.priming;
@@ -12,6 +13,7 @@ public class CustomJzonbie extends Jzonbie {
         super(
                 options()
                         .withPriming(priming(get("/"), ok()))
+                        .withHomePath(Files.temporaryFolder().getPath())
         );
     }
 

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/Jzonbie.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/Jzonbie.java
@@ -126,10 +126,10 @@ public class Jzonbie implements JzonbieClient {
         });
 
         final Handlebars handlebars = new JzonbieHandlebars();
-        final ResponseTransformer responseTransformer = new ResponseTransformer(handlebars);
-        final PippoResponder pippoResponder = new PippoResponder(responseTransformer, objectMapper);
+        final ResponseTransformer responseTransformer = new ResponseTransformer(objectMapper, handlebars);
+        final PippoResponder pippoResponder = new PippoResponder(objectMapper);
 
-        final PippoApplication application = new PippoApplication(options.getZombieHeaderName(), options.getRoutes(), appRequestHandler, zombieRequestHandler, pippoResponder);
+        final PippoApplication application = new PippoApplication(options.getZombieHeaderName(), options.getRoutes(), appRequestHandler, zombieRequestHandler, pippoResponder, responseTransformer);
 
         httpPippo = createPippo(application, options.getHttpPort());
         httpPippo.start();

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/JzonbieOptions.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/JzonbieOptions.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.jonnymatts.jzonbie.HttpsOptions.httpsOptions;
+import static java.lang.System.getProperty;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
@@ -52,6 +53,7 @@ public class JzonbieOptions {
     private static final List<Priming> DEFAULT_PRIMING = emptyList();
     private static final int DEFAULT_CALL_HISTORY_CAPACITY = 1000;
     private static final int DEFAULT_FAILED_REQUESTS_CAPACITY = 1000;
+    private static final String DEFAULT_HOME_PATH = getProperty("user.home");
 
     private int httpPort;
     private String zombieHeaderName;
@@ -64,6 +66,7 @@ public class JzonbieOptions {
     private int failedRequestsCapacity;
     private File initialPrimingFile;
     private File defaultPrimingFile;
+    private String homePath;
 
     private JzonbieOptions() {
         this.httpPort = DEFAULT_PORT;
@@ -73,6 +76,7 @@ public class JzonbieOptions {
         this.priming = DEFAULT_PRIMING;
         this.callHistoryCapacity = DEFAULT_CALL_HISTORY_CAPACITY;
         this.failedRequestsCapacity = DEFAULT_FAILED_REQUESTS_CAPACITY;
+        this.homePath = DEFAULT_HOME_PATH;
     }
 
     /**
@@ -239,6 +243,19 @@ public class JzonbieOptions {
         return this;
     }
 
+    /**
+     * Specifies the location of the '.jzonbie' home folder where Jzonbie context is stored.
+     *
+     * If not specified will default to '~/'
+     *
+     * @param homePath the Jzonbie home path
+     * @return this Jzonbie configuration with configured home path
+     */
+    public JzonbieOptions withHomePath(String homePath) {
+        this.homePath = homePath;
+        return this;
+    }
+
     public int getHttpPort() {
         return httpPort;
     }
@@ -279,5 +296,9 @@ public class JzonbieOptions {
 
     public Optional<File> getDefaultPrimingFile() {
         return Optional.ofNullable(defaultPrimingFile);
+    }
+
+    public String getHomePath() {
+        return homePath;
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/cli/CommandLineOptions.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/cli/CommandLineOptions.java
@@ -48,6 +48,10 @@ public class CommandLineOptions {
     @Option(names = {"--default-priming-file"}, paramLabel = "PATH", description = "path to default priming file JSON")
     public File defaultPrimingFile;
 
+    @Option(names = {"--home-path"}, paramLabel = "PATH", description = "path where Jzonbie home folder should be created")
+    public String homePath;
+
+
     public static CommandLineOptions parse(String[] args) {
         final CommandLine cmd = new CommandLine(CommandLineOptions.class);
         cmd.parseArgs(args);
@@ -89,6 +93,10 @@ public class CommandLineOptions {
         }
         if (commandLineOptions.defaultPrimingFile != null) {
             options.withDefaultPrimingFile(commandLineOptions.defaultPrimingFile);
+        }
+
+        if(commandLineOptions.homePath != null) {
+            options.withHomePath(commandLineOptions.homePath);
         }
         return options;
     }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistory.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistory.java
@@ -2,24 +2,31 @@ package com.jonnymatts.jzonbie.history;
 
 import com.jonnymatts.jzonbie.requests.AppRequest;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import static java.lang.String.valueOf;
+
 
 public class CallHistory {
 
-    private final FixedCapacityCache<Exchange> exchangeCache;
+    private final FixedCapacityCache<Exchange> messageHistoryCache;
     private final Map<AppRequest, Integer> successfulRequestCounter;
+    private final PersistentRequestCount persistentRequestCount;
 
-    public CallHistory(int capacity) {
-        exchangeCache = new FixedCapacityCache<>(capacity);
+    public CallHistory(int capacity, File persistedFile) {
+        messageHistoryCache = new FixedCapacityCache<>(capacity);
         successfulRequestCounter = new ConcurrentHashMap<>();
+        persistentRequestCount = new PersistentRequestCount(persistedFile);
     }
 
-    public void add(AppRequest foundAppRequest, Exchange exchange) {
-        incrementCounter(foundAppRequest);
-        exchangeCache.add(exchange);
+    public CallHistorySnapshot add(AppRequest foundAppRequest, Exchange exchange) {
+        int count = incrementCounter(foundAppRequest);
+        int persistedCount = persistentRequestCount.incrementCounter(valueOf(foundAppRequest.hashCode()));
+        messageHistoryCache.add(exchange);
+        return CallHistorySnapshot.snapshot(count, persistedCount);
     }
 
     public int count(AppRequest appRequest) {
@@ -27,19 +34,24 @@ public class CallHistory {
     }
 
     public List<Exchange> getValues() {
-        return exchangeCache.getValues();
+        return messageHistoryCache.getValues();
     }
 
-    private void incrementCounter(AppRequest request) {
-            if(successfulRequestCounter.get(request) == null) {
-                successfulRequestCounter.put(request, 1);
-            } else {
-                successfulRequestCounter.compute(request, (request1, size) -> size + 1);
-            }
+    public int getPersistedCount(AppRequest request) {
+        return persistentRequestCount.getCount(valueOf(request.hashCode())).orElse(0);
     }
 
     public void clear() {
         successfulRequestCounter.clear();
-        exchangeCache.clear();
+        messageHistoryCache.clear();
+    }
+
+    private int incrementCounter(AppRequest request) {
+        if (successfulRequestCounter.get(request) == null) {
+            successfulRequestCounter.put(request, 1);
+            return 1;
+        } else {
+            return successfulRequestCounter.compute(request, (request1, size) -> size + 1);
+        }
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistory.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistory.java
@@ -2,14 +2,44 @@ package com.jonnymatts.jzonbie.history;
 
 import com.jonnymatts.jzonbie.requests.AppRequest;
 
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-public class CallHistory extends FixedCapacityCache<Exchange> {
+
+public class CallHistory {
+
+    private final FixedCapacityCache<Exchange> exchangeCache;
+    private final Map<AppRequest, Integer> successfulRequestCounter;
 
     public CallHistory(int capacity) {
-        super(capacity);
+        exchangeCache = new FixedCapacityCache<>(capacity);
+        successfulRequestCounter = new ConcurrentHashMap<>();
+    }
+
+    public void add(AppRequest foundAppRequest, Exchange exchange) {
+        incrementCounter(foundAppRequest);
+        exchangeCache.add(exchange);
     }
 
     public int count(AppRequest appRequest) {
-        return (int)values.stream().filter(priming -> appRequest.matches(priming.getRequest())).count();
+        return successfulRequestCounter.getOrDefault(appRequest, 0);
+    }
+
+    public List<Exchange> getValues() {
+        return exchangeCache.getValues();
+    }
+
+    private void incrementCounter(AppRequest request) {
+            if(successfulRequestCounter.get(request) == null) {
+                successfulRequestCounter.put(request, 1);
+            } else {
+                successfulRequestCounter.compute(request, (request1, size) -> size + 1);
+            }
+    }
+
+    public void clear() {
+        successfulRequestCounter.clear();
+        exchangeCache.clear();
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistorySnapshot.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/CallHistorySnapshot.java
@@ -1,0 +1,23 @@
+package com.jonnymatts.jzonbie.history;
+
+public class CallHistorySnapshot {
+    private final int count;
+    private final int persistedCount;
+
+    private CallHistorySnapshot(int count, int persistedCount) {
+        this.count = count;
+        this.persistedCount = persistedCount;
+    }
+
+    public static CallHistorySnapshot snapshot(int count, int persistedCount) {
+        return new CallHistorySnapshot(count, persistedCount);
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    public int getPersistedCount() {
+        return persistedCount;
+    }
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/FixedCapacityCache.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/FixedCapacityCache.java
@@ -3,17 +3,17 @@ package com.jonnymatts.jzonbie.history;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 public class FixedCapacityCache<T> {
 
     private final int capacity;
-    final LinkedList<T> values;
+    private ConcurrentLinkedDeque<T> values;
 
     public FixedCapacityCache(int capacity) {
         this.capacity = capacity;
-        this.values = new LinkedList<>();
+        this.values = new ConcurrentLinkedDeque<>();
     }
 
     @JsonValue

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/PersistentRequestCount.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/history/PersistentRequestCount.java
@@ -1,0 +1,73 @@
+package com.jonnymatts.jzonbie.history;
+
+import com.jonnymatts.jzonbie.persistence.JzonbiePersistenceException;
+
+import java.io.File;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.OptionalInt;
+
+import static com.google.common.io.Files.readLines;
+import static java.lang.Integer.parseInt;
+import static java.nio.file.Files.write;
+
+public class PersistentRequestCount {
+    private final File fileLocation;
+
+    public PersistentRequestCount(File fileLocation) {
+        this.fileLocation = fileLocation;
+    }
+
+    public synchronized int incrementCounter(String requestKey) {
+        try {
+            ArrayList<String> result = new ArrayList<>();
+            boolean found = false;
+            int incrementedCount = 1;
+
+            for(String line : readLines(fileLocation, Charset.defaultCharset())) {
+                if (line.startsWith(requestKey)) {
+                    incrementedCount = incrementLine(result, line);
+                    found = true;
+                } else {
+                    result.add(line);
+                }
+            }
+
+            if(!found) {
+                result.add(requestKey + ":1");
+            }
+
+            write(fileLocation.toPath(), result);
+            return incrementedCount;
+        } catch (Exception e) {
+            throw new JzonbiePersistenceException("Failure incrementing persistence counter", e);
+        }
+    }
+
+    public synchronized OptionalInt getCount(String requestKey) {
+        try {
+            return readLines(fileLocation, Charset.defaultCharset()).stream()
+                    .filter(line -> line.startsWith(requestKey + ":"))
+                    .mapToInt(line -> parseInt(line.split(":")[1]))
+                    .findFirst();
+
+        } catch (Exception e) {
+            throw new JzonbiePersistenceException("Failure reading persistence count", e);
+        }
+    }
+
+    private int incrementLine(ArrayList<String> result, String line) {
+        final String[] splitLine = line.split(":");
+        final int incrementedValue = incrementValue(splitLine[1]);
+        result.add(createLine(splitLine[0], incrementedValue));
+        return incrementedValue;
+    }
+
+    private int incrementValue(String value) {
+        return parseInt(value) + 1;
+    }
+
+    private String createLine(String key, int value) {
+        return key + ":" + value;
+    }
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/junit/JzonbieExtension.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/junit/JzonbieExtension.java
@@ -88,7 +88,7 @@ public class JzonbieExtension implements ParameterResolver, BeforeAllCallback, B
         if(classAnnotation != null) {
             return classAnnotation.value();
         }
-        return Jzonbie.class;
+        return TestJzonbie.class;
     }
 
     @Target(TYPE)

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/junit/TestJzonbie.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/junit/TestJzonbie.java
@@ -1,0 +1,27 @@
+package com.jonnymatts.jzonbie.junit;
+
+import com.jonnymatts.jzonbie.Jzonbie;
+import com.jonnymatts.jzonbie.JzonbieOptions;
+
+import java.nio.file.Files;
+
+import static com.jonnymatts.jzonbie.JzonbieOptions.options;
+
+public class TestJzonbie extends Jzonbie {
+
+    public TestJzonbie() {
+        super(options().withHomePath(getTestZombieHomePath()));
+    }
+
+    public TestJzonbie(JzonbieOptions jzonbieOptions) {
+        super(jzonbieOptions.withHomePath(getTestZombieHomePath()));
+    }
+
+    private static String getTestZombieHomePath() {
+        try {
+            return Files.createTempDirectory("tempTestJzonbieDir").toAbsolutePath().toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Could not create Test Jzonbie", e);
+        }
+    }
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataContext.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataContext.java
@@ -1,27 +1,38 @@
-package com.jonnymatts.jzonbie.templating;
+package com.jonnymatts.jzonbie.metadata;
 
 import com.jonnymatts.jzonbie.pippo.PippoRequest;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
-public class TransformationContext {
+public class MetaDataContext {
 
-    public TransformationContext(PippoRequest request) {
+    private final RequestContext request;
+    private final Map<String, Object> processValues = new HashMap<>();
+
+    public MetaDataContext(PippoRequest request) {
         this(request.getProtocol(), request.getUrl(), request.getPort(),request.getPath(), request.getQueryParams(), request.getHeaders(), request.getMethod(), request.getBody());
     }
 
-    public TransformationContext(String protocol, String url, int port, String path, Map<String, List<String>> queryParams, Map<String, String> headers, String method, String body) {
+    public MetaDataContext(String protocol, String url, int port, String path, Map<String, List<String>> queryParams, Map<String, String> headers, String method, String body) {
         this.request = new RequestContext(protocol, url, port, path, queryParams, headers, method, body);
     }
 
-    public RequestContext request;
+    public Map<String, Object> getContext() {
+        Map<String, Object> context = new HashMap<>();
+        context.put("request", request);
+        context.putAll(processValues);
 
-    public RequestContext getRequest() {
-        return request;
+        return context;
+    }
+
+    public MetaDataContext withMetaData(MetaDataTag metaDataTag, Object value) {
+        processValues.put(metaDataTag.toString(), value);
+        return this;
     }
 
     public static class RequestContext {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataTag.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataTag.java
@@ -1,6 +1,6 @@
 package com.jonnymatts.jzonbie.metadata;
 
 public enum MetaDataTag {
-
-    ENDPOINT_REQUEST_COUNT
+    ENDPOINT_REQUEST_COUNT,
+    ENDPOINT_REQUEST_PERSISTENT_COUNT
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataTag.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/metadata/MetaDataTag.java
@@ -1,0 +1,6 @@
+package com.jonnymatts.jzonbie.metadata;
+
+public enum MetaDataTag {
+
+    ENDPOINT_REQUEST_COUNT
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/persistence/JzonbieFilePersistence.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/persistence/JzonbieFilePersistence.java
@@ -1,0 +1,39 @@
+package com.jonnymatts.jzonbie.persistence;
+
+
+import java.io.File;
+
+import static java.lang.String.format;
+import static java.nio.file.Paths.get;
+
+public class JzonbieFilePersistence {
+
+    private static final String JZONBIE_HOME_FOLDER_NAME = ".jzonbie";
+    private final File jzonbieHomePath;
+
+    public JzonbieFilePersistence(String jzonbieHomePath) {
+        this.jzonbieHomePath = get(jzonbieHomePath, JZONBIE_HOME_FOLDER_NAME).toFile();
+        this.jzonbieHomePath.mkdirs();
+    }
+
+    public File createFileIfNotAlreadyExists(String subPathIncludingFileName) {
+        File file = get(jzonbieHomePath.getPath(), subPathIncludingFileName).toFile();
+
+        try {
+            file.getParentFile().mkdirs();
+            file.createNewFile();
+            return file;
+        } catch (Exception e) {
+            throw new JzonbiePersistenceException("Could not create file", e);
+        }
+    }
+
+    public File findFile(String subPathToFile) {
+        final File file = get(jzonbieHomePath.getPath(), subPathToFile).toFile();
+        if(file.exists()) {
+            return file;
+        } else {
+            throw new JzonbiePersistenceException(format("Could not find file at %s", file.getPath()));
+        }
+    }
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/persistence/JzonbiePersistenceException.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/persistence/JzonbiePersistenceException.java
@@ -1,0 +1,12 @@
+package com.jonnymatts.jzonbie.persistence;
+
+public class JzonbiePersistenceException extends RuntimeException{
+
+    public JzonbiePersistenceException(String s) {
+        super(s);
+    }
+
+    public JzonbiePersistenceException(String s, Throwable throwable) {
+        super(s, throwable);
+    }
+}

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoApplication.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoApplication.java
@@ -1,9 +1,12 @@
 package com.jonnymatts.jzonbie.pippo;
 
 import com.google.common.base.Stopwatch;
+import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.requests.AppRequestHandler;
 import com.jonnymatts.jzonbie.requests.RequestHandler;
 import com.jonnymatts.jzonbie.requests.ZombieRequestHandler;
+import com.jonnymatts.jzonbie.templating.ResponseTransformer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ro.pippo.core.Application;
@@ -22,17 +25,20 @@ public class PippoApplication extends Application {
     private final AppRequestHandler appRequestHandler;
     private final ZombieRequestHandler zombieRequestHandler;
     private final PippoResponder pippoResponder;
+    private final ResponseTransformer responseTransformer;
 
     public PippoApplication(String zombieHeaderName,
                             List<JzonbieRoute> additionalRoutes,
                             AppRequestHandler appRequestHandler,
                             ZombieRequestHandler zombieRequestHandler,
-                            PippoResponder pippoResponder) {
+                            PippoResponder pippoResponder,
+                            ResponseTransformer responseTransformer) {
         this.zombieHeaderName = zombieHeaderName;
         this.additionalRoutes = additionalRoutes;
         this.appRequestHandler = appRequestHandler;
         this.zombieRequestHandler = zombieRequestHandler;
         this.pippoResponder = pippoResponder;
+        this.responseTransformer = responseTransformer;
     }
 
     @Override
@@ -50,10 +56,18 @@ public class PippoApplication extends Application {
 
         final RequestHandler requestHandler = zombieHeader != null ?
                 zombieRequestHandler : appRequestHandler;
-
-        pippoResponder.send(pippoResponse, pippoRequest, () -> requestHandler.handle(pippoRequest));
-
+        try {
+            pippoResponder.send(pippoResponse, getResponse(pippoRequest, requestHandler));
+        } catch (Exception e) {
+            pippoResponder.sendForException(pippoResponse, e);
+        }
         stopwatch.stop();
         LOGGER.debug("Handled request {} in {} ms", pippoRequest, stopwatch.elapsed(MILLISECONDS));
+    }
+
+    private Response getResponse(PippoRequest request, RequestHandler requestHandler) {
+        MetaDataContext context = new MetaDataContext(request);
+        Response response = requestHandler.handle(request, context);
+        return responseTransformer.transform(context, response);
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoRequest.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoRequest.java
@@ -28,15 +28,26 @@ public class PippoRequest implements Request {
     private final String primingFileContent;
 
     public PippoRequest(ro.pippo.core.Request request) {
-        protocol = request.getScheme();
-        url = request.getUrl();
-        port = request.getPort();
-        path = request.getPath();
-        method = request.getMethod();
-        headers = createHeaders(request);
-        body = request.getBody();
-        queryMap = createQueryMap(request);
-        primingFileContent = getPrimingFileContentFromRequest(request);
+        this(request.getScheme(),
+                request.getUrl(),
+                request.getPort(),
+                request.getPath(),
+                request.getMethod(),
+                createHeaders(request),
+                request.getBody(),
+                createQueryMap(request),
+                getPrimingFileContentFromRequest(request));
+    }
+    public PippoRequest(String protocol, String url, int port, String path, String method, Map<String, String> headers, String body, Map<String, List<String>> queryMap, String primingFileContent) {
+        this.protocol = protocol;
+        this.url = url;
+        this.port = port;
+        this.path = path;
+        this.method = method;
+        this.headers = headers;
+        this.body = body;
+        this.queryMap = queryMap;
+        this.primingFileContent = primingFileContent;
     }
 
     @Override
@@ -81,7 +92,7 @@ public class PippoRequest implements Request {
         return port;
     }
 
-    private Map<String,String> createHeaders(ro.pippo.core.Request request) {
+    private static Map<String, String> createHeaders(ro.pippo.core.Request request) {
         return list(request.getHttpServletRequest().getHeaderNames())
                 .stream()
                 .collect(
@@ -92,7 +103,7 @@ public class PippoRequest implements Request {
                 );
     }
 
-    private Map<String,List<String>> createQueryMap(ro.pippo.core.Request request) {
+    private static Map<String, List<String>> createQueryMap(ro.pippo.core.Request request) {
         return request.getQueryParameters().entrySet()
                 .stream()
                 .collect(
@@ -103,9 +114,10 @@ public class PippoRequest implements Request {
                 );
     }
 
-    private String getPrimingFileContentFromRequest(ro.pippo.core.Request request) {
+    private static String getPrimingFileContentFromRequest(ro.pippo.core.Request request) {
         final String contentType = request.getContentType();
-        if(contentType == null || !contentType.startsWith(FILE_CONTENT_TYPE) || request.getFiles().isEmpty()) return null;
+        if (contentType == null || !contentType.startsWith(FILE_CONTENT_TYPE) || request.getFiles().isEmpty())
+            return null;
         return of(request.getFile("priming"))
                 .map(fileItem -> {
                     try {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoResponder.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/pippo/PippoResponder.java
@@ -5,19 +5,17 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jonnymatts.jzonbie.Body;
 import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.body.LiteralBodyContent;
+import com.jonnymatts.jzonbie.requests.AppRequest;
 import com.jonnymatts.jzonbie.requests.PrimingNotFoundException;
 import com.jonnymatts.jzonbie.responses.CurrentPrimingFileResponseFactory.FileResponse;
 import com.jonnymatts.jzonbie.responses.ErrorResponse;
 import com.jonnymatts.jzonbie.responses.PrimingNotFoundErrorResponse;
-import com.jonnymatts.jzonbie.templating.ResponseTransformer;
-import com.jonnymatts.jzonbie.templating.TransformationContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.util.Map;
-import java.util.function.Supplier;
 
 import static java.lang.String.format;
 import static javax.servlet.http.HttpServletResponse.SC_INTERNAL_SERVER_ERROR;
@@ -28,41 +26,37 @@ public class PippoResponder {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(PippoApplication.class);
 
-    private final ResponseTransformer responseTransformer;
     private final ObjectMapper objectMapper;
 
-    public PippoResponder(ResponseTransformer responseTransformer, ObjectMapper objectMapper) {
-        this.responseTransformer = responseTransformer;
+    public PippoResponder(ObjectMapper objectMapper) {
         this.objectMapper = objectMapper;
     }
 
-    public void send(ro.pippo.core.Response pippoResponse, PippoRequest pippoRequest, Supplier<Response<?>> responseSupplier) {
+    public void send(ro.pippo.core.Response pippoResponse, Response response) {
         try {
-            final Response<?> response = responseSupplier.get();
             if(response instanceof FileResponse) {
                 final FileResponse fileResponse = (FileResponse) response;
                 pippoResponse.contentType(APPLICATION_JSON);
                 pippoResponse.file(fileResponse.getFileName(), new ByteArrayInputStream(fileResponse.getContents().getBytes()));
-            } else if(response.isTemplated()) {
-                final TransformationContext transformationContext = new TransformationContext(pippoRequest);
-                final Map<String, String> transformedHeaders = responseTransformer.transformHeaders(transformationContext, response.getHeaders());
-                primeResponse(pippoResponse, response.getStatusCode(), transformedHeaders);
-                sleepIfNecessary(response);
-                final String bodyString = getBodyString(response.getBody());
-                final String transformedBodyString = responseTransformer.transformBody(transformationContext, bodyString);
-                send(pippoResponse, transformedBodyString);
             } else {
                 primeResponse(pippoResponse, response.getStatusCode(), response.getHeaders());
                 sleepIfNecessary(response);
                 final String bodyString = getBodyString(response.getBody());
                 send(pippoResponse, bodyString);
             }
-        } catch (PrimingNotFoundException e) {
-            LOGGER.error("Priming not found for request {}", e.getRequest());
-            sendErrorResponse(pippoResponse, SC_NOT_FOUND, new PrimingNotFoundErrorResponse(e.getRequest()));
         } catch (Exception e) {
+            sendForException(pippoResponse, e);
+        }
+    }
+
+    public void sendForException(ro.pippo.core.Response response, Exception e) {
+        if(e.getClass().equals(PrimingNotFoundException.class)) {
+            AppRequest request = ((PrimingNotFoundException)e).getRequest();
+            LOGGER.error("Priming not found for request {}", request);
+            sendErrorResponse(response, SC_NOT_FOUND, new PrimingNotFoundErrorResponse(request));
+        } else {
             LOGGER.error("Exception occurred: " + e.getClass().getSimpleName(), e);
-            sendErrorResponse(pippoResponse, SC_INTERNAL_SERVER_ERROR, new ErrorResponse(format("Error occurred: %s - %s", e.getClass().getName(), e.getMessage())));
+            sendErrorResponse(response, SC_INTERNAL_SERVER_ERROR, new ErrorResponse(format("Error occurred: %s - %s", e.getClass().getName(), e.getMessage())));
         }
     }
 
@@ -74,7 +68,7 @@ public class PippoResponder {
         }
     }
 
-    private void sleepIfNecessary(Response<?> response) {
+    private void sleepIfNecessary(Response response) {
         response.getDelay().ifPresent(d -> {
             try {
                 Thread.sleep(d.toMillis());

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/priming/PrimingContext.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/priming/PrimingContext.java
@@ -1,6 +1,5 @@
 package com.jonnymatts.jzonbie.priming;
 
-import com.jonnymatts.jzonbie.Body;
 import com.jonnymatts.jzonbie.defaults.DefaultResponsePriming;
 import com.jonnymatts.jzonbie.defaults.Priming;
 import com.jonnymatts.jzonbie.defaults.StandardPriming;
@@ -9,20 +8,22 @@ import com.jonnymatts.jzonbie.responses.AppResponse;
 import com.jonnymatts.jzonbie.responses.defaults.DefaultAppResponse;
 import com.jonnymatts.jzonbie.responses.defaults.DefaultingQueue;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import static java.util.Collections.emptyList;
 import static java.util.Optional.empty;
-import static java.util.Optional.of;
 
 public class PrimingContext {
     private final List<Priming> priming;
-    private Map<HeaderlessAppRequest, Map<AppRequest, DefaultingQueue>> primedMappings;
+    private Map<AppRequest, DefaultingQueue> primedMappings;
 
     public PrimingContext(List<Priming> priming) {
         this.priming = priming;
-        this.primedMappings = new HashMap<>();
+        this.primedMappings = new ConcurrentHashMap<>();
         addDefaultPriming();
     }
 
@@ -30,8 +31,8 @@ public class PrimingContext {
         this(emptyList());
     }
 
-    synchronized public List<PrimedMapping> getCurrentPriming() {
-        return primedMappings.entrySet().stream().map(e -> e.getValue().entrySet()).flatMap(Collection::stream)
+    public List<PrimedMapping> getCurrentPriming() {
+        return primedMappings.entrySet().stream()
                 .map(e -> new PrimedMapping(e.getKey(), e.getValue()))
                 .collect(Collectors.toList());
     }
@@ -40,79 +41,49 @@ public class PrimingContext {
         return add(zombiePriming.getRequest(), zombiePriming.getResponse());
     }
 
-    synchronized public PrimingContext add(AppRequest appRequest, AppResponse appResponse) {
-        final DefaultingQueue responseQueue = getAppResponseQueueForAdd(appRequest);
-
-        responseQueue.add(appResponse);
+    public PrimingContext add(AppRequest appRequest, AppResponse appResponse) {
+        getAppResponseQueueForAdd(appRequest).add(appResponse);
 
         return this;
     }
 
-    synchronized public PrimingContext addDefault(AppRequest appRequest, DefaultAppResponse defaultAppResponse) {
-        final DefaultingQueue responseQueue = getAppResponseQueueForAdd(appRequest);
-
-        responseQueue.setDefault(defaultAppResponse);
+    public PrimingContext addDefault(AppRequest appRequest, DefaultAppResponse defaultAppResponse) {
+        getAppResponseQueueForAdd(appRequest).setDefault(defaultAppResponse);
 
         return this;
     }
 
-    private DefaultingQueue getAppResponseQueueForAdd(AppRequest appRequest) {
-        final HeaderlessAppRequest headerlessAppRequest = new HeaderlessAppRequest(appRequest);
-        Map<AppRequest, DefaultingQueue> mappingsForHeaderlessRequest = primedMappings
-                .computeIfAbsent(headerlessAppRequest, k -> new HashMap<>());
-
-        DefaultingQueue responseQueue = mappingsForHeaderlessRequest.get(appRequest);
-
-        if(responseQueue == null) {
-            responseQueue = new DefaultingQueue();
-            mappingsForHeaderlessRequest.put(appRequest, responseQueue);
-        }
-
-        return responseQueue;
+    public Optional<AppRequest> getPrimedRequest(AppRequest appRequest) {
+        return primedMappings.entrySet().parallelStream()
+                .filter(priming -> priming.getKey().matches(appRequest))
+                .map(Map.Entry::getKey)
+                .findFirst();
     }
 
-    synchronized public Optional<AppResponse> getResponse(AppRequest appRequest) {
-        final HeaderlessAppRequest headerlessAppRequest = new HeaderlessAppRequest(appRequest);
-        final Optional<MapAppRequestAndQueue> mapAppRequestAndQueue = findMapAndQueue(appRequest);
+    public Optional<AppResponse> getResponse(AppRequest appRequest) {
+        final DefaultingQueue primedResponsesQueue = primedMappings.get(appRequest);
 
-        if (!mapAppRequestAndQueue.isPresent())
+        if (primedResponsesQueue == null) {
             return empty();
+        }
 
-        return mapAppRequestAndQueue.map(m -> {
-            final DefaultingQueue responseQueue = m.getQueue();
-            final Map<AppRequest, DefaultingQueue> mapping = m.getMap();
+        final AppResponse appResponse = primedResponsesQueue.poll();
 
-            final AppResponse appResponse = responseQueue.poll();
+        if (primedResponsesQueue.hasSize() == 0 && !primedResponsesQueue.getDefault().isPresent()) {
+            primedMappings.remove(appRequest);
+        }
 
-            if(responseQueue.hasSize() == 0 && !responseQueue.getDefault().isPresent())
-                mapping.remove(m.getAppRequest());
-
-            if(mapping.isEmpty())
-                primedMappings.remove(headerlessAppRequest);
-            return appResponse;
-        });
+        return Optional.ofNullable(appResponse);
     }
 
-    private Optional<MapAppRequestAndQueue> findMapAndQueue(AppRequest appRequest) {
-        final HeaderlessAppRequest headerlessAppRequest = new HeaderlessAppRequest(appRequest);
-        Map<AppRequest, DefaultingQueue> map = primedMappings.get(headerlessAppRequest);
-        if(map == null) {
-            for (Map<AppRequest, DefaultingQueue> e : primedMappings.values()) {
-                final Optional<Map.Entry<AppRequest, DefaultingQueue>> entryOpt = findResponseQueueFromMapForRequest(e, appRequest);
-                if(entryOpt.isPresent()) {
-                    final Map.Entry<AppRequest, DefaultingQueue> entry = entryOpt.get();
-                    return of(new MapAppRequestAndQueue(e, entry.getKey(), entry.getValue()));
-                }
-            }
-        } else {
-            return findResponseQueueFromMapForRequest(map, appRequest).map(q -> new MapAppRequestAndQueue(map, q.getKey(), q.getValue()));
-        }
-        return empty();
+    public void reset() {
+        primedMappings.clear();
+        addDefaultPriming();
     }
 
     private void addDefaultPriming() {
         for (Priming priming : priming) {
-            if(priming instanceof StandardPriming) {
+            if (priming instanceof StandardPriming) {
                 final StandardPriming defaultPriming = (StandardPriming) priming;
                 add(defaultPriming.getRequest(), defaultPriming.getResponse());
             } else {
@@ -122,75 +93,12 @@ public class PrimingContext {
         }
     }
 
-    private static class MapAppRequestAndQueue {
-        private final Map<AppRequest, DefaultingQueue> map;
-        private final AppRequest appRequest;
-        private final DefaultingQueue queue;
-
-        public MapAppRequestAndQueue(Map<AppRequest, DefaultingQueue> map, AppRequest appRequest, DefaultingQueue queue) {
-            this.map = map;
-            this.appRequest = appRequest;
-            this.queue = queue;
-        }
-
-        public Map<AppRequest, DefaultingQueue> getMap() {
-            return map;
-        }
-
-        public AppRequest getAppRequest() {
-            return appRequest;
-        }
-
-        public DefaultingQueue getQueue() {
-            return queue;
-        }
-    }
-
-    private Optional<Map.Entry<AppRequest, DefaultingQueue>> findResponseQueueFromMapForRequest(Map<AppRequest, DefaultingQueue> map, AppRequest appRequest) {
-        return map.entrySet().parallelStream()
-                .filter(priming -> priming.getKey().matches(appRequest))
-                .findFirst();
-    }
-
-    synchronized public void reset() {
-        primedMappings.clear();
-        addDefaultPriming();
-    }
-
-    private static class HeaderlessAppRequest {
-        private final String path;
-        private final String method;
-        private final Body<?> body;
-        private final Map<String, List<String>> queryParams;
-
-        private HeaderlessAppRequest(AppRequest appRequest) {
-            this.path = appRequest.getPath();
-            this.method = appRequest.getMethod();
-            this.body = appRequest.getBody();
-            this.queryParams = appRequest.getQueryParams();
-        }
-
-        @Override
-        public boolean equals(Object o) {
-            if(this == o) return true;
-            if(o == null || getClass() != o.getClass()) return false;
-
-            HeaderlessAppRequest that = (HeaderlessAppRequest) o;
-
-            if(path != null ? !path.equals(that.path) : that.path != null) return false;
-            if(method != null ? !method.equals(that.method) : that.method != null) return false;
-            if(body != null ? !body.getContent().equals(that.body.getContent()) : that.body != null) return false;
-            return queryParams != null ? queryParams.equals(that.queryParams) : that.queryParams == null;
-
-        }
-
-        @Override
-        public int hashCode() {
-            int result = path != null ? path.hashCode() : 0;
-            result = 31 * result + (method != null ? method.hashCode() : 0);
-            result = 31 * result + (body != null ? body.getContent().hashCode() : 0);
-            result = 31 * result + (queryParams != null ? queryParams.hashCode() : 0);
-            return result;
+    private DefaultingQueue getAppResponseQueueForAdd(AppRequest appRequest) {
+        if (primedMappings.get(appRequest) == null) {
+            primedMappings.put(appRequest, new DefaultingQueue());
+            return primedMappings.get(appRequest);
+        } else {
+            return primedMappings.get(appRequest);
         }
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/AppRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/AppRequestHandler.java
@@ -46,7 +46,7 @@ public class AppRequestHandler implements RequestHandler {
 
             final AppResponse zombieResponse = primedResponseOpt.get();
 
-        callHistory.add(new Exchange(appRequest, zombieResponse));
+        callHistory.add(primedRequest, new Exchange(appRequest, zombieResponse));
 
             return zombieResponse;
         } else {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/AppRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/AppRequestHandler.java
@@ -3,15 +3,18 @@ package com.jonnymatts.jzonbie.requests;
 import com.jonnymatts.jzonbie.Request;
 import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.history.CallHistory;
+import com.jonnymatts.jzonbie.history.CallHistorySnapshot;
 import com.jonnymatts.jzonbie.history.Exchange;
 import com.jonnymatts.jzonbie.history.FixedCapacityCache;
 import com.jonnymatts.jzonbie.metadata.MetaDataContext;
-import com.jonnymatts.jzonbie.metadata.MetaDataTag;
 import com.jonnymatts.jzonbie.priming.AppRequestFactory;
 import com.jonnymatts.jzonbie.priming.PrimingContext;
 import com.jonnymatts.jzonbie.responses.AppResponse;
 
 import java.util.Optional;
+
+import static com.jonnymatts.jzonbie.metadata.MetaDataTag.ENDPOINT_REQUEST_COUNT;
+import static com.jonnymatts.jzonbie.metadata.MetaDataTag.ENDPOINT_REQUEST_PERSISTENT_COUNT;
 
 public class AppRequestHandler implements RequestHandler {
 
@@ -47,9 +50,9 @@ public class AppRequestHandler implements RequestHandler {
 
             final AppResponse zombieResponse = primedResponseOpt.get();
 
-            callHistory.add(primedRequest, new Exchange(appRequest, zombieResponse));
+            CallHistorySnapshot callHistorySnapshot = callHistory.add(primedRequest, new Exchange(appRequest, zombieResponse));
 
-            populateMetaData(primedRequest, metaDataContext);
+            populateMetaData(callHistorySnapshot, metaDataContext);
             return zombieResponse;
         } else {
             failedRequests.add(appRequest);
@@ -57,7 +60,8 @@ public class AppRequestHandler implements RequestHandler {
         }
     }
 
-    private void populateMetaData(AppRequest primedRequest, MetaDataContext metaDataContext) {
-        metaDataContext.withMetaData(MetaDataTag.ENDPOINT_REQUEST_COUNT, callHistory.count(primedRequest));
+    private void populateMetaData(CallHistorySnapshot callHistorySnapshot, MetaDataContext metaDataContext) {
+        metaDataContext.withMetaData(ENDPOINT_REQUEST_COUNT, callHistorySnapshot.getCount());
+        metaDataContext.withMetaData(ENDPOINT_REQUEST_PERSISTENT_COUNT, callHistorySnapshot.getPersistedCount());
     }
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/RequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/RequestHandler.java
@@ -2,8 +2,9 @@ package com.jonnymatts.jzonbie.requests;
 
 import com.jonnymatts.jzonbie.Request;
 import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 
 public interface RequestHandler {
 
-    Response handle(Request request);
+    Response handle(Request request, MetaDataContext metaDataContext);
 }

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
@@ -5,6 +5,7 @@ import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.history.CallHistory;
 import com.jonnymatts.jzonbie.history.FixedCapacityCache;
 import com.jonnymatts.jzonbie.jackson.Deserializer;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.priming.PrimedMapping;
 import com.jonnymatts.jzonbie.priming.PrimingContext;
 import com.jonnymatts.jzonbie.priming.ZombiePriming;
@@ -51,7 +52,7 @@ public class ZombieRequestHandler implements RequestHandler {
     }
 
     @Override
-    public Response handle(Request request) {
+    public Response handle(Request request, MetaDataContext metaDataContext) {
         final String zombieHeaderValue = request.getHeaders().get(zombieHeaderName);
 
         switch(zombieHeaderValue) {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
@@ -64,6 +64,8 @@ public class ZombieRequestHandler implements RequestHandler {
                 return handleFilePrimingRequest(request);
             case "count":
                 return handleCountRequest(request);
+            case "persistent-count":
+                return handlePersistentCountRequest(request);
             case "current":
                 return handleCurrentPrimingRequest();
             case "current-file":
@@ -126,6 +128,12 @@ public class ZombieRequestHandler implements RequestHandler {
     private ZombieResponse handleCountRequest(Request request) {
         final AppRequest appRequest = deserializer.deserialize(request, AppRequest.class);
         final int count = callHistory.count(appRequest);
+        return new ZombieResponse(OK_200, new CountResult(count));
+    }
+
+    private ZombieResponse handlePersistentCountRequest(Request request) {
+        final AppRequest appRequest = deserializer.deserialize(request, AppRequest.class);
+        final int count = callHistory.getPersistedCount(appRequest);
         return new ZombieResponse(OK_200, new CountResult(count));
     }
 

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandler.java
@@ -115,7 +115,7 @@ public class ZombieRequestHandler implements RequestHandler {
     }
 
     private ZombieResponse handleHistoryRequest() {
-        return new ZombieResponse(OK_200, callHistory);
+        return new ZombieResponse(OK_200, callHistory.getValues());
     }
 
     private ZombieResponse handleFailedRequest() {

--- a/jzonbie/src/main/java/com/jonnymatts/jzonbie/templating/ResponseTransformer.java
+++ b/jzonbie/src/main/java/com/jonnymatts/jzonbie/templating/ResponseTransformer.java
@@ -1,7 +1,14 @@
 package com.jonnymatts.jzonbie.templating;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.jknack.handlebars.Handlebars;
 import com.github.jknack.handlebars.Template;
+import com.jonnymatts.jzonbie.Body;
+import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.body.LiteralBodyContent;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
+import com.jonnymatts.jzonbie.responses.AppResponse;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -9,33 +16,66 @@ import java.util.Map;
 import static java.lang.String.format;
 
 public class ResponseTransformer {
+    private final ObjectMapper objectMapper;
     private final Handlebars handlebars;
 
-    public ResponseTransformer(Handlebars handlebars) {
+    public ResponseTransformer(ObjectMapper objectMapper, Handlebars handlebars) {
+        this.objectMapper = objectMapper;
         this.handlebars = handlebars;
     }
 
-    public Map<String, String> transformHeaders(TransformationContext transformationContext, Map<String, String> headers) {
-        if(headers == null) return null;
+    public Response transform(MetaDataContext metaDataContext, Response appResponse) {
+        try {
+            if (appResponse.isTemplated()) {
+                Map<String, String> responseHeaders = appResponse.getHeaders();
+                final Map<String, String> transformedHeaders = transformHeaders(metaDataContext, responseHeaders);
+                final String transformedBody = transformBody(metaDataContext, getBodyString(appResponse.getBody()));
+                return buildNewResponse(appResponse.getStatusCode(), transformedHeaders, transformedBody);
+            } else {
+                return appResponse;
+            }
+        } catch(TransformResponseException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new TransformResponseException(e);
+        }
+    }
+
+    private Map<String, String> transformHeaders(MetaDataContext metaDataContext, Map<String, String> headers) {
+        if (headers == null) return null;
         final Map<String, String> transformedHeaders = new HashMap<>();
 
-        for(Map.Entry<String, String> header : headers.entrySet()) {
-            final String transformedValue = transformValue(transformationContext, header.getValue());
+        for (Map.Entry<String, String> header : headers.entrySet()) {
+            final String transformedValue = transformValue(metaDataContext, header.getValue());
             transformedHeaders.put(header.getKey(), transformedValue);
         }
         return transformedHeaders;
     }
 
-    public String transformBody(TransformationContext transformationContext, String bodyString) {
-        return transformValue(transformationContext, bodyString);
+    private String transformBody(MetaDataContext metaDataContext, String bodyString) {
+        return transformValue(metaDataContext, bodyString);
     }
 
-    private String transformValue(TransformationContext transformationContext, String value) {
+    private String transformValue(MetaDataContext metaDataContext, String value) {
         try {
             final Template template = handlebars.compileInline(value);
-            return template.apply(transformationContext);
+           return template.apply(metaDataContext.getContext());
         } catch (Exception e) {
             throw new TransformResponseException(format("Could not transform: %s", value), e);
         }
     }
+
+    private Response buildNewResponse(int statusCode, Map<String, String> newHeaders, String transformedBody) {
+        final AppResponse response = new AppResponse(statusCode);
+        response.setHeaders(newHeaders);
+        response.withBody(transformedBody);
+        return response;
+    }
+
+    private String getBodyString(Body<?> body) throws JsonProcessingException {
+        if (body == null) return null;
+        if (body instanceof LiteralBodyContent) return ((LiteralBodyContent) body).getContent();
+        return objectMapper.writeValueAsString(body.getContent());
+    }
+
 }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieHttpsTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieHttpsTest.java
@@ -11,12 +11,14 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.ssl.SSLContexts;
+import org.assertj.core.util.Files;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import sun.security.x509.X509CertImpl;
 
 import javax.net.ssl.SSLContext;
+import java.io.File;
 import java.io.FileInputStream;
 import java.security.KeyStore;
 import java.security.cert.Certificate;
@@ -26,6 +28,7 @@ import static com.jonnymatts.jzonbie.JzonbieOptions.options;
 import static com.jonnymatts.jzonbie.requests.AppRequest.get;
 import static com.jonnymatts.jzonbie.responses.AppResponse.ok;
 import static com.jonnymatts.jzonbie.responses.defaults.DefaultAppResponse.staticDefault;
+import static java.nio.file.Paths.get;
 import static org.apache.http.HttpStatus.SC_OK;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -100,10 +103,11 @@ class JzonbieHttpsTest {
 
     @Test
     void jzonbieCanSetCommonNameOfDefaultSslCertificate() throws Exception {
-        new Jzonbie(options().withHttps(HttpsOptions.httpsOptions().withCommonName("notLocalHost")));
+        File tempRoot = Files.temporaryFolder();
+        new Jzonbie(options().withHomePath(tempRoot.getPath()).withHttps(HttpsOptions.httpsOptions().withCommonName("notLocalHost")));
 
         final KeyStore keystore = KeyStore.getInstance("jks");
-        keystore.load(new FileInputStream("/tmp/jzonbie.jks"), "jzonbie".toCharArray());
+        keystore.load(new FileInputStream(get(tempRoot.getPath(), ".jzonbie", "/ssl/jzonbie.jks").toFile()), "jzonbie".toCharArray());
 
         final Certificate certificate = keystore.getCertificate("jzonbie");
 

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieHttpsTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieHttpsTest.java
@@ -1,6 +1,7 @@
 package com.jonnymatts.jzonbie;
 
 import com.google.common.io.Resources;
+import com.jonnymatts.jzonbie.junit.TestJzonbie;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -34,8 +35,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class JzonbieHttpsTest {
 
-    private static final Jzonbie defaultHttpsJzonbie = new Jzonbie(options().withHttps());
-    private static final Jzonbie configuredHttpsJzonbie = new Jzonbie(options().withHttps(httpsOptions().withKeystoreLocation(Resources.getResource("test.jks").toString()).withKeystorePassword("jzonbie")));
+    private static final Jzonbie defaultHttpsJzonbie = new TestJzonbie(options().withHttps());
+    private static final Jzonbie configuredHttpsJzonbie = new TestJzonbie(options().withHttps(httpsOptions().withKeystoreLocation(Resources.getResource("test.jks").toString()).withKeystorePassword("jzonbie")));
 
     private HttpUriRequest httpRequest;
     private HttpUriRequest defaultHttpsRequest;
@@ -104,7 +105,7 @@ class JzonbieHttpsTest {
     @Test
     void jzonbieCanSetCommonNameOfDefaultSslCertificate() throws Exception {
         File tempRoot = Files.temporaryFolder();
-        new Jzonbie(options().withHomePath(tempRoot.getPath()).withHttps(HttpsOptions.httpsOptions().withCommonName("notLocalHost")));
+        new TestJzonbie(options().withHttps(HttpsOptions.httpsOptions().withCommonName("notLocalHost")));
 
         final KeyStore keystore = KeyStore.getInstance("jks");
         keystore.load(new FileInputStream(get(tempRoot.getPath(), ".jzonbie", "/ssl/jzonbie.jks").toFile()), "jzonbie".toCharArray());

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieTest.java
@@ -24,6 +24,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
@@ -514,6 +517,16 @@ class JzonbieTest {
         Jzonbie jzonbieWithDefaultPrimings = new Jzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()).withPriming(priming(get("/"), ok())));
 
         assertThat(jzonbieWithDefaultPrimings.getCurrentPriming()).hasSize(2);
+    }
+
+    @Test
+    void canConfigureJzonbieHomePath() throws IOException {
+        Path rootPath = Files.createTempDirectory("tempDirectory");
+        new Jzonbie(options().withHomePath(rootPath.toString()));
+
+        File file = Paths.get(rootPath.toString(), ".jzonbie").toFile();
+
+        assertThat(file.exists()).isTrue();
     }
 
     void callJzonbieWithRequest(int times, Jzonbie jzonbie, AppRequest request, AppResponse response, boolean shouldPrime) throws IOException {

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/JzonbieTest.java
@@ -3,6 +3,7 @@ package com.jonnymatts.jzonbie;
 import com.google.common.base.Stopwatch;
 import com.jonnymatts.jzonbie.client.ApacheJzonbieHttpClient;
 import com.jonnymatts.jzonbie.junit.JzonbieExtension;
+import com.jonnymatts.jzonbie.junit.TestJzonbie;
 import com.jonnymatts.jzonbie.pippo.JzonbieRoute;
 import com.jonnymatts.jzonbie.priming.PrimedMapping;
 import com.jonnymatts.jzonbie.requests.AppRequest;
@@ -175,7 +176,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieCanBePrimedWithAnInitialPrimingFile() {
-        Jzonbie jzonbieWithInitialPrimings = new Jzonbie(options().withInitialPrimingFile(getExamplePrimingFile()));
+        Jzonbie jzonbieWithInitialPrimings = new TestJzonbie(options().withInitialPrimingFile(getExamplePrimingFile()));
 
         final List<PrimedMapping> currentPriming = jzonbieWithInitialPrimings.getCurrentPriming();
 
@@ -184,7 +185,7 @@ class JzonbieTest {
 
     @Test
     void initialPrimingWithAFileIsRemovedOnReset() {
-        Jzonbie jzonbieWithInitialPrimings = new Jzonbie(options().withInitialPrimingFile(getExamplePrimingFile()));
+        Jzonbie jzonbieWithInitialPrimings = new TestJzonbie(options().withInitialPrimingFile(getExamplePrimingFile()));
 
         jzonbieWithInitialPrimings.reset();
 
@@ -196,14 +197,14 @@ class JzonbieTest {
     @Test
     void jzonbieWithAMissingInitialPrimingFile() {
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(
-                () -> new Jzonbie(options().withInitialPrimingFile(new File("missing")))
+                () -> new TestJzonbie(options().withInitialPrimingFile(new File("missing")))
         ).withCauseInstanceOf(FileNotFoundException.class);
     }
 
     @Test
     void zombieHeaderNameCanBeSet() {
         final String zombieHeaderName = "jzonbie";
-        final Jzonbie jzonbieWithZombieHeaderNameSet = new Jzonbie(options().withZombieHeaderName(zombieHeaderName));
+        final Jzonbie jzonbieWithZombieHeaderNameSet = new TestJzonbie(options().withZombieHeaderName(zombieHeaderName));
 
         final AppRequest request = get("/");
         final AppResponse response = ok().withBody(objectBody(singletonMap("key", "val")));
@@ -275,7 +276,7 @@ class JzonbieTest {
 
     @Test
     void stopDoesNotDelayIfNotConfiguredTo() {
-        final Jzonbie jzonbie = new Jzonbie(options());
+        final Jzonbie jzonbie = new TestJzonbie();
 
         final Stopwatch stopwatch = Stopwatch.createStarted();
         jzonbie.stop();
@@ -287,7 +288,7 @@ class JzonbieTest {
     @Test
     void waitAfterStopCanBeConfigured() {
         final Duration waitAfterStopFor = Duration.ofSeconds(2);
-        final Jzonbie jzonbie = new Jzonbie(options().withWaitAfterStopping(waitAfterStopFor));
+        final Jzonbie jzonbie = new TestJzonbie(options().withWaitAfterStopping(waitAfterStopFor));
 
         final Stopwatch stopwatch = Stopwatch.createStarted();
         jzonbie.stop();
@@ -298,7 +299,7 @@ class JzonbieTest {
 
     @Test
     void additionalRoutesCanBeAdded() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(options().withRoutes(JzonbieRoute.get("/ready", ctx -> ctx.getRouteContext().getResponse().ok())));
+        final Jzonbie jzonbie = new TestJzonbie(options().withRoutes(JzonbieRoute.get("/ready", ctx -> ctx.getRouteContext().getResponse().ok())));
 
         try {
             final HttpResponse got = client.execute(RequestBuilder.get("http://localhost:" + jzonbie.getHttpPort() + "/ready").build());
@@ -311,7 +312,7 @@ class JzonbieTest {
 
     @Test
     void additionalRoutesOverridePriming() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(options().withRoutes(JzonbieRoute.get("/ready", ctx -> ctx.getRouteContext().getResponse().ok())));
+        final Jzonbie jzonbie = new TestJzonbie(options().withRoutes(JzonbieRoute.get("/ready", ctx -> ctx.getRouteContext().getResponse().ok())));
 
         try {
             jzonbie.prime(get("/ready"), internalServerError());
@@ -326,7 +327,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieReturns404FoundNonPrimedRequest() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(
+        final Jzonbie jzonbie = new TestJzonbie(
                 options().withPriming(
                         priming(get("/"), ok())
                 )
@@ -347,7 +348,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieCanBePrimedWithDefaultResponseDefaultPriming() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(
+        final Jzonbie jzonbie = new TestJzonbie(
                 options().withPriming(
                         priming(get("/"), ok()),
                         defaultPriming(get("/default"), staticDefault(ok()))
@@ -369,7 +370,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieCanBePrimedWithTemplatedResponseDefaultPriming() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(
+        final Jzonbie jzonbie = new TestJzonbie(
                 options().withPriming(
                         priming(get("/path"), ok()),
                         defaultPriming(get("/default/templated/path"), staticDefault(ok().templated().withBody(literalBody("{{ request.path }}"))))
@@ -400,7 +401,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieCanBePrimedWithRequestSessionCountTemplateDefaultPriming() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(
+        final Jzonbie jzonbie = new TestJzonbie(
                 options().withPriming(
                         defaultPriming(get("/default/templated/path"), staticDefault(ok().templated().withBody(literalBody("{{ ENDPOINT_REQUEST_COUNT }}"))))
                 )
@@ -429,7 +430,7 @@ class JzonbieTest {
     }
 
     @Test
-    void jzonbieCanBePrimedWithRequestSessionCountTemplatePriming() throws IOException {
+    void jzonbieCanBePrimedWithEndpointRequestCountTemplatePriming() throws IOException {
         final Jzonbie jzonbie = new Jzonbie(
                 options().withPriming(
                         priming(get("/default/templated/path"), ok().templated().withBody(literalBody("{{ ENDPOINT_REQUEST_COUNT }}1"))),
@@ -461,6 +462,52 @@ class JzonbieTest {
     }
 
     @Test
+    void jzonbieCanBePrimedWithEndpointRequestPersistentCountTemplatePriming() throws IOException {
+        File tempHome = org.assertj.core.util.Files.newTemporaryFolder();
+        Jzonbie jzonbie = new Jzonbie(
+                options().withHomePath(tempHome.getPath())
+                        .withPriming(
+                        priming(get("/default/templated/path"), ok().templated().withBody(literalBody("{{ ENDPOINT_REQUEST_PERSISTENT_COUNT }}1"))),
+                        priming(get("/default/templated/path"), ok().templated().withBody(literalBody("{{ ENDPOINT_REQUEST_PERSISTENT_COUNT }}1")))
+                )
+        );
+
+        try {
+            final String path = "/default/templated/path";
+            final HttpResponse got1 = client.execute(RequestBuilder.get("http://localhost:" + jzonbie.getHttpPort() + path).build());
+
+            assertThat(got1.getStatusLine().getStatusCode()).isEqualTo(SC_OK);
+            assertThat(EntityUtils.toString(got1.getEntity())).isEqualTo("11");
+
+            final HttpResponse got2 = client.execute(RequestBuilder.get("http://localhost:" + jzonbie.getHttpPort() + path).build());
+
+            assertThat(got2.getStatusLine().getStatusCode()).isEqualTo(SC_OK);
+            assertThat(EntityUtils.toString(got2.getEntity())).isEqualTo("21");
+
+             jzonbie = new Jzonbie(
+                    options().withHomePath(tempHome.getPath())
+                            .withPriming(
+                            priming(get("/default/templated/path"), ok().templated().withBody(literalBody("{{ ENDPOINT_REQUEST_PERSISTENT_COUNT }}1"))),
+                            priming(get("/default/templated/path"), ok().templated().withBody(literalBody("{{ ENDPOINT_REQUEST_PERSISTENT_COUNT }}1")))
+                            )
+            );
+
+            final HttpResponse got3 = client.execute(RequestBuilder.get("http://localhost:" + jzonbie.getHttpPort() + path).build());
+
+            assertThat(got3.getStatusLine().getStatusCode()).isEqualTo(SC_OK);
+            assertThat(EntityUtils.toString(got3.getEntity())).isEqualTo("31");
+
+            final HttpResponse got4 = client.execute(RequestBuilder.get("http://localhost:" + jzonbie.getHttpPort() + path).build());
+
+            assertThat(got4.getStatusLine().getStatusCode()).isEqualTo(SC_OK);
+            assertThat(EntityUtils.toString(got4.getEntity())).isEqualTo("41");
+
+        } finally {
+            jzonbie.stop();
+        }
+    }
+
+    @Test
     void getHttpsPortThrowsExceptionIfHttpsIsNotConfigured(Jzonbie jzonbie) {
         assertThatThrownBy(jzonbie::getHttpsPort)
                 .isExactlyInstanceOf(IllegalStateException.class)
@@ -469,7 +516,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieCallHistoryCapacityCanBeSet() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(
+        final Jzonbie jzonbie = new TestJzonbie(
                 options().withCallHistoryCapacity(2)
         );
 
@@ -480,7 +527,7 @@ class JzonbieTest {
 
     @Test
     void jzonbieFailedRequestsCapacityCanBeSet() throws IOException {
-        final Jzonbie jzonbie = new Jzonbie(
+        final Jzonbie jzonbie = new TestJzonbie(
                 options().withFailedRequestsCapacity(2)
         );
 
@@ -491,14 +538,14 @@ class JzonbieTest {
 
     @Test
     void jzonbieCanBePrimedWithAnDefaultPrimingFile() {
-        Jzonbie jzonbieWithDefaultPrimings = new Jzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()));
+        Jzonbie jzonbieWithDefaultPrimings = new TestJzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()));
 
         assertPrimingFromExamplePrimingFile(jzonbieWithDefaultPrimings.getCurrentPriming());
     }
 
     @Test
     void initialPrimingWithAFileIsNotRemovedOnReset() {
-        Jzonbie jzonbieWithDefaultPrimings = new Jzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()));
+        Jzonbie jzonbieWithDefaultPrimings = new TestJzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()));
 
         jzonbieWithDefaultPrimings.reset();
 
@@ -508,13 +555,13 @@ class JzonbieTest {
     @Test
     void jzonbieWithAMissingDefaultPrimingFile() {
         assertThatExceptionOfType(RuntimeException.class).isThrownBy(
-                () -> new Jzonbie(options().withDefaultPrimingFile(new File("missing")))
+                () -> new TestJzonbie(options().withDefaultPrimingFile(new File("missing")))
         ).withCauseInstanceOf(FileNotFoundException.class);
     }
 
     @Test
     void jzonbieCanAddPrimingThroughAFileAndJavaOptions() {
-        Jzonbie jzonbieWithDefaultPrimings = new Jzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()).withPriming(priming(get("/"), ok())));
+        Jzonbie jzonbieWithDefaultPrimings = new TestJzonbie(options().withDefaultPrimingFile(getExamplePrimingFile()).withPriming(priming(get("/"), ok())));
 
         assertThat(jzonbieWithDefaultPrimings.getCurrentPriming()).hasSize(2);
     }
@@ -527,6 +574,24 @@ class JzonbieTest {
         File file = Paths.get(rootPath.toString(), ".jzonbie").toFile();
 
         assertThat(file.exists()).isTrue();
+    }
+
+    @Test
+    void jzonbieCanGetAppRequestsCount() throws IOException {
+        final Jzonbie jzonbie = new TestJzonbie();
+
+        callJzonbieWithRequest(4, jzonbie, get("/"), ok(), true);
+
+        assertThat(jzonbie.getCount(get("/"))).isEqualTo(4);
+    }
+
+    @Test
+    void jzonbieCanGetAppRequestsPersistentCount() throws IOException {
+        final Jzonbie jzonbie = new TestJzonbie();
+
+        callJzonbieWithRequest(4, jzonbie, get("/"), ok(), true);
+
+        assertThat(jzonbie.getPersistentCount(get("/"))).isEqualTo(4);
     }
 
     void callJzonbieWithRequest(int times, Jzonbie jzonbie, AppRequest request, AppResponse response, boolean shouldPrime) throws IOException {

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/cli/CommandLineOptionsTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/cli/CommandLineOptionsTest.java
@@ -139,6 +139,12 @@ class CommandLineOptionsTest {
     }
 
     @Test
+    void canSetJzonbieHomePath() {
+        CommandLineOptions commandLineOptions = getCommandLineOptions("--home-path", "/path/this");
+        assertThat(commandLineOptions.homePath).isEqualTo("/path/this");
+    }
+
+    @Test
     void toJzonbieOptions() {
         final JzonbieOptions jzonbieOptions = CommandLineOptions.toJzonbieOptions(
                 CommandLineOptions.parse(new String[]{
@@ -153,6 +159,7 @@ class CommandLineOptionsTest {
                                 "--failed-requests-capacity", "50",
                                 "--initial-priming-file", "initial",
                                 "--default-priming-file", "default",
+                                "--home-path", "/home/path"
                         }
                 )
         );
@@ -163,6 +170,7 @@ class CommandLineOptionsTest {
         assertThat(jzonbieOptions.getFailedRequestsCapacity()).isEqualTo(50);
         assertThat(jzonbieOptions.getInitialPrimingFile()).contains(new File("initial"));
         assertThat(jzonbieOptions.getDefaultPrimingFile()).contains(new File("default"));
+        assertThat(jzonbieOptions.getHomePath()).contains("/home/path");
 
         final HttpsOptions httpsOptions = jzonbieOptions.getHttpsOptions().get();
         assertThat(httpsOptions.getPort()).isEqualTo(8001);

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/CallHistoryTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/CallHistoryTest.java
@@ -2,8 +2,11 @@ package com.jonnymatts.jzonbie.history;
 
 
 import com.jonnymatts.jzonbie.requests.AppRequest;
+import org.assertj.core.util.Files;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import java.io.File;
 
 import static com.jonnymatts.jzonbie.requests.AppRequest.get;
 import static com.jonnymatts.jzonbie.responses.AppResponse.ok;
@@ -12,13 +15,59 @@ import static org.assertj.core.api.Assertions.assertThat;
 class CallHistoryTest {
 
     private final AppRequest primedRequest = get("1");
-    private final Exchange exchange1 = new Exchange(get("1"), ok());
+    private final AppRequest primedRequest2 = get("2");
+    private final Exchange exchange1 = new Exchange(primedRequest, ok());
+    private final Exchange exchange2 = new Exchange(primedRequest2, ok());
 
     private CallHistory underTest;
+    private File persistedFile;
 
     @BeforeEach
     void setUp() {
-        underTest = new CallHistory(3);
+        persistedFile = Files.newTemporaryFile();
+        underTest = new CallHistory(3, persistedFile);
+    }
+
+    @Test
+    void addReturnsAccurateSnapshotOfHistory() {
+        CallHistorySnapshot snapshot = underTest.add(primedRequest, exchange1);
+
+        assertThat(snapshot.getCount()).isEqualTo(1);
+        assertThat(snapshot.getPersistedCount()).isEqualTo(1);
+    }
+
+    @Test
+    void addReturnsAccurateSnapshotOfHistoryForResetHistory() {
+        underTest.add(primedRequest, exchange1);
+        underTest.clear();
+        CallHistorySnapshot snapshot = underTest.add(primedRequest, exchange1);
+
+        assertThat(snapshot.getCount()).isEqualTo(1);
+        assertThat(snapshot.getPersistedCount()).isEqualTo(2);
+    }
+
+    @Test
+    void addReturnsAccurateSnapshotOfHistoryForMultipleRequests() {
+        CallHistorySnapshot snapshot = underTest.add(primedRequest, exchange1);
+
+        underTest.add(primedRequest2, exchange2);
+        CallHistorySnapshot snapshotTwo = underTest.add(primedRequest2, exchange2);
+
+        assertThat(snapshot.getCount()).isEqualTo(1);
+        assertThat(snapshot.getPersistedCount()).isEqualTo(1);
+
+        assertThat(snapshotTwo.getCount()).isEqualTo(2);
+        assertThat(snapshotTwo.getPersistedCount()).isEqualTo(2);
+    }
+
+    @Test
+    void addCanContinueToIncrementOverMultipleInstances() {
+        underTest.add(exchange1.getRequest(), exchange1);
+        new CallHistory(6, persistedFile).add(exchange1.getRequest(), exchange1);
+
+        final CallHistorySnapshot snapshot = new CallHistory(5, persistedFile).add(exchange1.getRequest(), exchange1);
+        assertThat(snapshot.getCount()).isEqualTo(1);
+        assertThat(snapshot.getPersistedCount()).isEqualTo(3);
     }
 
     @Test
@@ -48,5 +97,45 @@ class CallHistoryTest {
         final int got = underTest.count(exchange1.getRequest());
 
         assertThat(got).isEqualTo(0);
+    }
+
+    @Test
+    void countReturnsPersistedRequestCountOfMatchingRequestWhenHistoryHasASingleRequest() throws Exception {
+        underTest.add(primedRequest, exchange1);
+
+        final int got = underTest.getPersistedCount(exchange1.getRequest());
+
+        assertThat(got).isEqualTo(1);
+    }
+
+    @Test
+    void canPersistCountOverMultipleInstances() {
+        underTest.add(exchange1.getRequest(), exchange1);
+        new CallHistory(6, persistedFile).add(exchange1.getRequest(), exchange1);
+
+        assertThat(new CallHistory(5, persistedFile).getPersistedCount(exchange1.getRequest())).isEqualTo(2);
+    }
+
+    @Test
+    void persistedCountReturnsZeroWhenRequestNotFound() throws Exception {
+        final int got = underTest.getPersistedCount(exchange1.getRequest());
+
+        assertThat(got).isEqualTo(0);
+    }
+
+    @Test
+    void clearOnlyClearsNonPersistentStores() {
+        underTest.add(exchange1.getRequest(), exchange1);
+        underTest.add(exchange1.getRequest(), exchange1);
+        underTest.add(exchange1.getRequest(), exchange1);
+
+        underTest.clear();
+
+        final int count = underTest.count(exchange1.getRequest());
+        final int persistentCount = underTest.getPersistedCount(exchange1.getRequest());
+
+        assertThat(count).isEqualTo(0);
+        assertThat(underTest.getValues()).isEmpty();
+        assertThat(persistentCount).isEqualTo(3);
     }
 }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/CallHistoryTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/CallHistoryTest.java
@@ -1,6 +1,7 @@
 package com.jonnymatts.jzonbie.history;
 
 
+import com.jonnymatts.jzonbie.requests.AppRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -10,6 +11,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CallHistoryTest {
 
+    private final AppRequest primedRequest = get("1");
     private final Exchange exchange1 = new Exchange(get("1"), ok());
 
     private CallHistory underTest;
@@ -21,11 +23,24 @@ class CallHistoryTest {
 
     @Test
     void countReturnsRequestCountOfMatchingRequestWhenHistoryHasASingleRequest() throws Exception {
-        underTest.add(exchange1);
+        underTest.add(primedRequest, exchange1);
 
         final int got = underTest.count(exchange1.getRequest());
 
         assertThat(got).isEqualTo(1);
+    }
+
+    @Test
+    void countIsNotAffectedBySizeOfHistoryCache() throws Exception {
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+        underTest.add(primedRequest, exchange1);
+
+        final int got = underTest.count(exchange1.getRequest());
+
+        assertThat(got).isEqualTo(5);
     }
 
     @Test

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/PersistentRequestCountTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/history/PersistentRequestCountTest.java
@@ -1,0 +1,173 @@
+package com.jonnymatts.jzonbie.history;
+
+import com.jonnymatts.jzonbie.persistence.JzonbiePersistenceException;
+import org.assertj.core.util.Files;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.OptionalInt;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+import static java.nio.file.Files.createTempFile;
+import static java.nio.file.Files.lines;
+import static java.util.concurrent.Executors.newFixedThreadPool;
+import static java.util.stream.IntStream.range;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+class PersistentRequestCountTest {
+
+    private static final String REQUEST_KEY = "requestKey";
+    private static final String NEW_REQUEST_KEY = "newRequestKey";
+
+    @Test
+    void addNewCounterEntryToFile() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        PersistentRequestCount underTest = new PersistentRequestCount(fileLocation);
+
+        final int count = underTest.incrementCounter(REQUEST_KEY);
+
+        assertThatFileHasLineMatching(fileLocation, REQUEST_KEY + ":1");
+        assertThat(count).isEqualTo(1);
+    }
+
+    @Test
+    void canIncrementCounterOnExistingEntry() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        PersistentRequestCount underTest = new PersistentRequestCount(fileLocation);
+
+        underTest.incrementCounter(REQUEST_KEY);
+        final int count = underTest.incrementCounter(REQUEST_KEY);
+
+        assertThatFileHasLineMatching(fileLocation, REQUEST_KEY + ":2");
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void keyMatchesRequestKey() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        PersistentRequestCount underTest = new PersistentRequestCount(fileLocation);
+
+        underTest.incrementCounter("newRequestKey");
+
+        assertThatFileHasLineMatching(fileLocation, NEW_REQUEST_KEY + ":1");
+    }
+
+    @Test
+    void incrementMultipleCounterEntriesOnFile() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        PersistentRequestCount underTest = new PersistentRequestCount(fileLocation);
+
+        underTest.incrementCounter(REQUEST_KEY);
+        underTest.incrementCounter(NEW_REQUEST_KEY);
+
+        underTest.incrementCounter(NEW_REQUEST_KEY);
+        final int requestCount = underTest.incrementCounter(REQUEST_KEY);
+        final int newRequestCount = underTest.incrementCounter(NEW_REQUEST_KEY);
+
+        assertThatFileHasLineMatching(fileLocation, REQUEST_KEY + ":2");
+        assertThatFileHasLineMatching(fileLocation, NEW_REQUEST_KEY + ":3");
+        assertThat(requestCount).isEqualTo(2);
+        assertThat(newRequestCount).isEqualTo(3);
+    }
+
+    @Test
+    void missingFileThrowsJzonbiePersistenceException() {
+        assertThatThrownBy(() -> new PersistentRequestCount(new File("missingFileLocation")).incrementCounter(REQUEST_KEY))
+                .hasMessage("Failure incrementing persistence counter")
+                .isInstanceOf(JzonbiePersistenceException.class);
+    }
+
+    @Test
+    void invalidFileThrowsJzonbiePersistenceException() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        try(FileWriter writer = new FileWriter(fileLocation)) {
+         writer.write(REQUEST_KEY+":content");
+        }
+
+        assertThatThrownBy(() -> new PersistentRequestCount(fileLocation).incrementCounter(REQUEST_KEY))
+                .hasMessage("Failure incrementing persistence counter")
+                .isInstanceOf(JzonbiePersistenceException.class);
+    }
+
+    @Test
+    void getCountFromPersistedFile() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        PersistentRequestCount underTest = new PersistentRequestCount(fileLocation);
+
+        underTest.incrementCounter(REQUEST_KEY);
+        underTest.incrementCounter(REQUEST_KEY);
+        final int count = underTest.getCount(REQUEST_KEY).getAsInt();
+
+        assertThat(count).isEqualTo(2);
+    }
+
+    @Test
+    void getCountFromPersistedFileThatDoesNotExistReturnsOptionalEmpty() throws IOException {
+        File fileLocation = createTempFile("a", "b").toFile();
+
+        PersistentRequestCount underTest = new PersistentRequestCount(fileLocation);
+
+        underTest.incrementCounter(REQUEST_KEY);
+        final OptionalInt optionalCount = underTest.getCount("missingKey");
+
+        assertThat(optionalCount).isEmpty();
+    }
+
+    @Test
+    void getCountFromPersistedFileWithMissingFileThrowsJzonbiePersistenceException() throws IOException {
+        PersistentRequestCount underTest = new PersistentRequestCount(new File("nonExistentFile"));
+
+        assertThatThrownBy(() -> underTest.getCount(REQUEST_KEY))
+                .isInstanceOf(JzonbiePersistenceException.class);
+    }
+
+    @Test
+    void persistAllCountsWhenWritingConcurrently() {
+        final String key = "key1234";
+        PersistentRequestCount underTest = new PersistentRequestCount(Files.newTemporaryFile());
+        range(1, 50).parallel().forEach( i -> underTest.incrementCounter(key));
+
+        assertThat(underTest.getCount(key).getAsInt()).isEqualTo(49);
+    }
+
+    @Test
+    void cannotReadWhilstWritingToFile() throws Exception {
+        final String key = "key1234";
+        PersistentRequestCount underTest = new PersistentRequestCount(Files.newTemporaryFile());
+        CountDownLatch latch = new CountDownLatch(1);
+
+        ExecutorService executorService = newFixedThreadPool(3);
+        File mockedFile = spy(Files.newTemporaryFile());
+
+        when(mockedFile.getPath()).then(invocation -> {
+            while(latch.getCount() > 0){}
+            return invocation;
+        }).thenCallRealMethod();
+
+        executorService.execute(() -> underTest.incrementCounter(key));
+
+        latch.countDown();
+        Future<Integer> count = executorService.submit(() -> underTest.getCount(key).getAsInt());
+
+        assertThat(count.get()).isEqualTo(1);
+
+    }
+
+    private void assertThatFileHasLineMatching(File fileLocation, String lineExpected) throws IOException {
+        assertThat(lines(fileLocation.toPath())).contains(lineExpected);
+    }
+
+}

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/junit/CustomJzonbie.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/junit/CustomJzonbie.java
@@ -1,6 +1,7 @@
 package com.jonnymatts.jzonbie.junit;
 
 import com.jonnymatts.jzonbie.Jzonbie;
+import org.assertj.core.util.Files;
 
 import static com.jonnymatts.jzonbie.JzonbieOptions.options;
 import static com.jonnymatts.jzonbie.defaults.StandardPriming.priming;
@@ -12,6 +13,7 @@ class CustomJzonbie extends Jzonbie {
         super(
                 options()
                         .withPriming(priming(get("/"), ok()))
+                        .withHomePath(Files.temporaryFolder().getPath())
         );
     }
 

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/persistence/JzonbieFilePersistenceTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/persistence/JzonbieFilePersistenceTest.java
@@ -73,9 +73,12 @@ public class JzonbieFilePersistenceTest {
     }
 
     @Test
-    void findFileThrowsJzonbiePersistenceExceptionWhenErrorOccurs() {
-        assertThatThrownBy(() -> new JzonbieFilePersistence("fakePath").findFile("missingFile"))
-        .hasMessage("Could not find file at fakePath/.jzonbie/missingFile")
+    void findFileThrowsJzonbiePersistenceExceptionWhenErrorOccurs() throws IOException {
+        Path tempJzonbieHome = Files.createTempDirectory(".tempJzonbieHome");
+
+        assertThatThrownBy(() -> new JzonbieFilePersistence(tempJzonbieHome.toAbsolutePath().toString()).findFile("missingFile"))
+        .hasMessageContaining("Could not find file at")
+        .hasMessageContaining(tempJzonbieHome.toAbsolutePath().toString())
         .isInstanceOf(JzonbiePersistenceException.class);
     }
 

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/persistence/JzonbieFilePersistenceTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/persistence/JzonbieFilePersistenceTest.java
@@ -1,0 +1,93 @@
+package com.jonnymatts.jzonbie.persistence;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Scanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+public class JzonbieFilePersistenceTest {
+
+    private static final String FILE_CONTENT = "This is the contents of the file";
+    @Test
+    void canCreateFoldersAndFileInJzonbieHome() throws IOException {
+        Path tempJzonbieHome = Files.createTempDirectory(".tempJzonbieHome");
+
+        JzonbieFilePersistence underTest = new JzonbieFilePersistence(tempJzonbieHome.toString());
+
+        File file = underTest.createFileIfNotAlreadyExists("/subFolder/file.txt");
+
+        assertThat(file.exists()).isTrue();
+    }
+
+    @Test
+    void doesNotOverwriteFileIfAlreadyCreated() throws IOException {
+        //Given
+        Path tempJzonbieHome = Files.createTempDirectory(".tempJzonbieHome");
+        JzonbieFilePersistence underTest = new JzonbieFilePersistence(tempJzonbieHome.toString());
+
+        File file = underTest.createFileIfNotAlreadyExists("/subFolder/file.txt");
+
+        writeContentToFile(file, FILE_CONTENT);
+
+        //When
+        underTest.createFileIfNotAlreadyExists("/subFolder/file.txt");
+
+        //Then
+        assertThat(getFirstLineFromFile(file)).isEqualTo(FILE_CONTENT);
+    }
+
+    @Test
+    void readFileInSubFolderInJzonbieHome() throws IOException {
+        Path tempJzonbieHome = Files.createTempDirectory(".tempJzonbieHome");
+
+        JzonbieFilePersistence underTest = new JzonbieFilePersistence(tempJzonbieHome.toString());
+
+        File file = underTest.createFileIfNotAlreadyExists("/subFolder/file.txt");
+        try(FileWriter writer = new FileWriter(file)) {
+            writer.write("This is the contents of the file");
+        }
+
+        File foundFile = underTest.findFile("/subFolder/file.txt");
+        try (final Scanner scanner = new Scanner(foundFile)) {
+            assertThat(scanner.nextLine()).isEqualTo("This is the contents of the file");
+        }
+    }
+
+    @Test
+    void createFileIfNotAlreadyExistsThrowsJzonbiePersistenceExceptionWhenErrorOccurs() throws IOException {
+        Path tempJzonbieHome = Files.createTempDirectory(".tempJzonbieHome");
+
+        new JzonbieFilePersistence(tempJzonbieHome.toString()).createFileIfNotAlreadyExists("fakeFolder");
+
+        assertThatThrownBy(() -> new JzonbieFilePersistence(tempJzonbieHome.toString()).createFileIfNotAlreadyExists("fakeFolder/realFile.txt"))
+        .hasMessage("Could not create file")
+        .isInstanceOf(JzonbiePersistenceException.class);
+    }
+
+    @Test
+    void findFileThrowsJzonbiePersistenceExceptionWhenErrorOccurs() {
+        assertThatThrownBy(() -> new JzonbieFilePersistence("fakePath").findFile("missingFile"))
+        .hasMessage("Could not find file at fakePath/.jzonbie/missingFile")
+        .isInstanceOf(JzonbiePersistenceException.class);
+    }
+
+    private void writeContentToFile(File file, String content) throws IOException {
+        try(FileWriter writer = new FileWriter(file)) {
+            writer.write(content);
+        }
+    }
+
+    private String getFirstLineFromFile(File file) throws FileNotFoundException {
+        try(Scanner scanner = new Scanner(file)) {
+            return  scanner.nextLine();
+        }
+    }
+}

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/pippo/PippoApplicationTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/pippo/PippoApplicationTest.java
@@ -204,7 +204,7 @@ class PippoApplicationTest {
 
     @Test
     void testHistory() throws Exception {
-        callHistory.add(exchange);
+        callHistory.add(appRequest, exchange);
 
         final Response pippoResponse = given()
                 .header("zombie", "history")
@@ -233,7 +233,7 @@ class PippoApplicationTest {
     @Test
     void testReset() throws Exception {
         primingContext.add(zombiePriming);
-        callHistory.add(exchange);
+        callHistory.add(appRequest, exchange);
         failedRequests.add(appRequest);
 
         final Response pippoResponse = given()
@@ -367,7 +367,7 @@ class PippoApplicationTest {
                 .withBody(objectBody(singletonMap("key", "val")));
         final AppResponse appResponse = ok();
 
-        callHistory.add(new Exchange(appRequest, appResponse));
+        callHistory.add(appRequest, new Exchange(appRequest, appResponse));
 
         final Response pippoResponse = given()
                 .header("zombie", "count")

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/pippo/PippoApplicationTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/pippo/PippoApplicationTest.java
@@ -25,6 +25,7 @@ import io.restassured.RestAssured;
 import io.restassured.http.ContentType;
 import io.restassured.response.Response;
 import org.hamcrest.CoreMatchers;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -48,40 +49,56 @@ import static java.util.Collections.singletonMap;
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
+import static org.assertj.core.util.Files.newTemporaryFile;
 import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.Matchers.startsWith;
 
 class PippoApplicationTest {
 
-    private static PrimingContext primingContext = new PrimingContext();
-    private static final CallHistory callHistory = new CallHistory(3);
-    private static final FixedCapacityCache<AppRequest> failedRequests = new FixedCapacityCache<>(3);
-    private static final ObjectMapper objectMapper = new JzonbieObjectMapper();
-    private static final Deserializer deserializer = new Deserializer(objectMapper);
-    private static final AppRequestHandler appRequestHandler = new AppRequestHandler(primingContext, callHistory, failedRequests, new AppRequestFactory(deserializer));
-    private static final PrimedMappingUploader primedMappingUploader = new PrimedMappingUploader(primingContext);
-    private static final ZombieRequestHandler zombieRequestHandler = new ZombieRequestHandler("zombie", primingContext, callHistory, failedRequests, deserializer, new CurrentPrimingFileResponseFactory(objectMapper), primedMappingUploader, new HttpsSupport());
-    private static final ResponseTransformer responseTransformer = new ResponseTransformer(objectMapper, new JzonbieHandlebars());
-    private static final PippoResponder pippoResponder = new PippoResponder(objectMapper);
+    private PrimingContext primingContext = new PrimingContext();
+    private ObjectMapper objectMapper = new JzonbieObjectMapper();
+    private Deserializer deserializer = new Deserializer(objectMapper);
 
+    private FixedCapacityCache<AppRequest> failedRequests;
+    private CallHistory callHistory;
+
+    private Pippo pippo;
     private AppRequest appRequest;
     private AppResponse appResponse;
     private ZombiePriming zombiePriming;
     private Exchange exchange;
 
+    PippoApplication application;
     @BeforeAll
     static void beforeAll() {
-        final PippoApplication application = new PippoApplication("zombie", singletonList(JzonbieRoute.get("/ready", c -> c.getRouteContext().getResponse().ok())), appRequestHandler, zombieRequestHandler, pippoResponder, responseTransformer);
-        final Pippo pippo = new Pippo(application);
-        pippo.start();
-        RestAssured.port = pippo.getServer().getPort();
+
+    }
+
+    @AfterEach
+    void tearDown() {
+        pippo.stop();
     }
 
     @BeforeEach
     void setUp() throws Exception {
-        primingContext.reset();
-        callHistory.clear();
-        failedRequests.clear();
+        callHistory = new CallHistory(3, newTemporaryFile());
+        failedRequests = new FixedCapacityCache<>(3);
+
+
+        AppRequestHandler appRequestHandler = new AppRequestHandler(primingContext, callHistory, failedRequests, new AppRequestFactory(deserializer));
+        PrimedMappingUploader primedMappingUploader = new PrimedMappingUploader(primingContext);
+        ZombieRequestHandler zombieRequestHandler = new ZombieRequestHandler("zombie", primingContext, callHistory, failedRequests, deserializer, new CurrentPrimingFileResponseFactory(objectMapper), primedMappingUploader, new HttpsSupport());
+        ResponseTransformer responseTransformer = new ResponseTransformer(objectMapper, new JzonbieHandlebars());
+        PippoResponder pippoResponder = new PippoResponder(objectMapper);
+        application = new PippoApplication("zombie", singletonList(JzonbieRoute.get("/ready", c -> c.getRouteContext().getResponse().ok())), appRequestHandler, zombieRequestHandler, pippoResponder, responseTransformer);
+        pippo = new Pippo(application);
+        pippo.start();
+        RestAssured.port = pippo.getServer().getPort();
+
+//         primingContext.reset();
+//        persistentFile = Files.newTemporaryFile();
+//        callHistory.clear();
+//        failedRequests.clear();
 
         appRequest = AppRequest.get("");
         appResponse = ok();
@@ -434,7 +451,7 @@ class PippoApplicationTest {
     }
 
     @Test
-    void testAppRequestWithRequestCounterTemplatePriming() throws Exception {
+    void testAppRequestWithEndpointRequestCountTemplatePriming() throws Exception {
         final AppRequest request = AppRequest.get("/path");
         final AppResponse response =
                 ok().withHeader("requestCounter", "{{ ENDPOINT_REQUEST_COUNT }}")
@@ -459,6 +476,31 @@ class PippoApplicationTest {
                 .body(equalTo("{\"requestCounter\": \"2\"}"));
     }
 
+    @Test
+    void testAppRequestWithEndpointRequestPersistedCountTemplatePriming() {
+        final AppRequest request = AppRequest.get("/path");
+        final AppResponse response =
+                ok().withHeader("requestCounter", "{{ ENDPOINT_REQUEST_PERSISTENT_COUNT }}")
+                        .withBody(literalBody("{\"requestCounter\": \"{{ ENDPOINT_REQUEST_PERSISTENT_COUNT }}\"}"))
+                        .templated();
+
+        primingContext.add(request, response);
+        primingContext.add(request, response);
+
+        final Response pippoResponse1 = given()
+                .get("/path");
+
+        pippoResponse1.then()
+                .header("requestCounter", "1")
+                .body(equalTo("{\"requestCounter\": \"1\"}"));
+
+        final Response pippoResponse2 = given()
+                .get("/path");
+
+        pippoResponse2.then()
+                .header("requestCounter", "2")
+                .body(equalTo("{\"requestCounter\": \"2\"}"));
+    }
 
     @Test
     void testUp() {
@@ -467,5 +509,24 @@ class PippoApplicationTest {
                 .get("/");
         pippoResponse.then().statusCode(200);
         pippoResponse.then().body("message", equalTo("Up!"));
+    }
+
+    @Test
+    void testPersistentCount() throws Exception {
+        final AppRequest appRequest = AppRequest.get("/")
+                .withBody(objectBody(singletonMap("key", "val")));
+        final AppResponse appResponse = ok();
+
+        callHistory.add(appRequest, new Exchange(appRequest, appResponse));
+
+        final Response pippoResponse = given()
+                .header("zombie", "persistent-count")
+                .contentType(ContentType.JSON)
+                .body(objectMapper.writeValueAsString(appRequest))
+                .post("/");
+
+        pippoResponse.then().assertThat()
+                .statusCode(200)
+                .body("count", equalTo(1));
     }
 }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/priming/PrimingContextTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/priming/PrimingContextTest.java
@@ -188,8 +188,8 @@ class PrimingContextTest {
         primingContext.add(zombiePriming);
 
         final AppRequest copy = new AppRequest(zombiePriming.getRequest()).withHeader("extra", "header");
-
-        primingContext.getResponse(copy);
+        AppRequest foundAppRequest = primingContext.getPrimedRequest(copy).get();
+        primingContext.getResponse(foundAppRequest);
 
         final List<PrimedMapping> currentPriming = primingContext.getCurrentPriming();
 

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
@@ -6,6 +6,7 @@ import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.history.CallHistory;
 import com.jonnymatts.jzonbie.history.Exchange;
 import com.jonnymatts.jzonbie.history.FixedCapacityCache;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.priming.AppRequestFactory;
 import com.jonnymatts.jzonbie.priming.PrimingContext;
 import com.jonnymatts.jzonbie.priming.ZombiePriming;
@@ -32,6 +33,7 @@ class AppRequestHandlerTest {
     @Mock private FixedCapacityCache<AppRequest> failedRequests;
     @Mock private AppRequestFactory appRequestFactory;
     @Mock private Request request;
+    @Mock private MetaDataContext metaDataContext;
 
     private ZombiePriming zombiePriming;
     private Exchange exchange;
@@ -60,7 +62,7 @@ class AppRequestHandlerTest {
         when(primingContext.getPrimedRequest(appRequest)).thenReturn(of(appRequest));
         when(primingContext.getResponse(appRequest))
                 .thenReturn(of(appResponse));
-        final Response got = appRequestHandler.handle(request);
+        final Response got = appRequestHandler.handle(request, metaDataContext);
 
         assertThat(got).isEqualTo(appResponse);
     }
@@ -70,14 +72,14 @@ class AppRequestHandlerTest {
         when(primingContext.getPrimedRequest(appRequest)).thenReturn(of(appRequest));
         when(primingContext.getResponse(appRequest))
                 .thenReturn(of(appResponse));
-        appRequestHandler.handle(request);
+        appRequestHandler.handle(request, metaDataContext);
 
         verify(callHistory).add(appRequest, exchange);
     }
 
     @Test
     void handleThrowsPrimingNotFoundExceptionIfPrimingIsNotFound() throws Exception {
-        assertThatThrownBy(() -> appRequestHandler.handle(request))
+        assertThatThrownBy(() -> appRequestHandler.handle(request, metaDataContext))
                 .isExactlyInstanceOf(PrimingNotFoundException.class)
                 .hasFieldOrPropertyWithValue("request", appRequest);
     }
@@ -85,7 +87,7 @@ class AppRequestHandlerTest {
     @Test
     void handleAddsRequestToFailedRequestsIfPrimingIsNotFound() throws Exception {
         try{
-            appRequestHandler.handle(request);
+            appRequestHandler.handle(request, metaDataContext);
         } catch (Exception e) {
             verify(failedRequests).add(appRequest);
         }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
@@ -1,95 +1,108 @@
 package com.jonnymatts.jzonbie.requests;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.jonnymatts.jzonbie.Request;
 import com.jonnymatts.jzonbie.Response;
 import com.jonnymatts.jzonbie.history.CallHistory;
 import com.jonnymatts.jzonbie.history.Exchange;
 import com.jonnymatts.jzonbie.history.FixedCapacityCache;
+import com.jonnymatts.jzonbie.jackson.Deserializer;
 import com.jonnymatts.jzonbie.metadata.MetaDataContext;
 import com.jonnymatts.jzonbie.priming.AppRequestFactory;
 import com.jonnymatts.jzonbie.priming.PrimingContext;
-import com.jonnymatts.jzonbie.priming.ZombiePriming;
 import com.jonnymatts.jzonbie.responses.AppResponse;
+import org.assertj.core.util.Files;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
+
+import static com.jonnymatts.jzonbie.metadata.MetaDataTag.ENDPOINT_REQUEST_COUNT;
+import static com.jonnymatts.jzonbie.metadata.MetaDataTag.ENDPOINT_REQUEST_PERSISTENT_COUNT;
 import static com.jonnymatts.jzonbie.requests.AppRequest.get;
-import static com.jonnymatts.jzonbie.responses.AppResponse.ok;
-import static java.util.Optional.of;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class AppRequestHandlerTest {
 
-    @Mock private PrimingContext primingContext;
-    @Mock private CallHistory callHistory;
-    @Mock private FixedCapacityCache<AppRequest> failedRequests;
-    @Mock private AppRequestFactory appRequestFactory;
-    @Mock private Request request;
-    @Mock private MetaDataContext metaDataContext;
+    private static final String UNKNOWN_PATH = "/unknownPath";
+    private static final String GET_METHOD = "GET";
+    private static final String RESPONSE_BODY = "Hello every-Body";
 
-    private ZombiePriming zombiePriming;
-    private Exchange exchange;
-
+    private CallHistory callHistory;
+    private FixedCapacityCache<AppRequest> failedRequests;
     private AppRequestHandler appRequestHandler;
+    private MetaDataContext metaDataContext;
 
-    private AppRequest appRequest;
-
-    private AppResponse appResponse;
+    @Mock private Request request;
 
     @BeforeEach
-    void setUp() throws Exception {
+    void setUp() {
+        PrimingContext primingContext = new PrimingContext();
+        primingContext.add(get("/primed"), AppResponse.ok().withBody(RESPONSE_BODY));
+        AppRequestFactory appRequestFactory = new AppRequestFactory(new Deserializer());
+
+        callHistory = new CallHistory(3, Files.newTemporaryFile());
+        failedRequests = new FixedCapacityCache<>(3);
         appRequestHandler = new AppRequestHandler(primingContext, callHistory, failedRequests, appRequestFactory);
+        metaDataContext = new MetaDataContext("http", "http://url.com", 80, "/path/here", Collections.emptyMap(), Collections.emptyMap(), GET_METHOD, RESPONSE_BODY);
 
-        appRequest = get("/");
-        appResponse = ok();
-
-        zombiePriming = new ZombiePriming(appRequest, appResponse);
-        exchange = new Exchange(appRequest, appResponse);
-
-        when(appRequestFactory.create(request)).thenReturn(appRequest);
+        when(request.getPath()).thenReturn("/primed");
+        when(request.getMethod()).thenReturn("GET");
     }
 
     @Test
     void handleReturnsPrimedResponseIfPrimingKeyExistsInPrimingContext() {
-        when(primingContext.getPrimedRequest(appRequest)).thenReturn(of(appRequest));
-        when(primingContext.getResponse(appRequest))
-                .thenReturn(of(appResponse));
         final Response got = appRequestHandler.handle(request, metaDataContext);
 
-        assertThat(got).isEqualTo(appResponse);
+        assertThat(got.getBody().getContent()).isEqualTo(RESPONSE_BODY);
     }
 
     @Test
-    void handleAddsPrimingRequestToCallHistory() throws JsonProcessingException {
-        when(primingContext.getPrimedRequest(appRequest)).thenReturn(of(appRequest));
-        when(primingContext.getResponse(appRequest))
-                .thenReturn(of(appResponse));
+    void handleAddsPrimingRequestToCallHistory() {
+        Exchange expectedExchange = new Exchange(get("/primed"), AppResponse.ok().withBody(RESPONSE_BODY));
+
         appRequestHandler.handle(request, metaDataContext);
 
-        verify(callHistory).add(appRequest, exchange);
+        assertThat(callHistory.getValues().get(0)).isEqualTo(expectedExchange);
+        assertThat(callHistory.getValues().size()).isEqualTo(1);
     }
 
     @Test
-    void handleThrowsPrimingNotFoundExceptionIfPrimingIsNotFound() throws Exception {
+    void handleThrowsPrimingNotFoundExceptionIfPrimingIsNotFound() {
+        when(request.getPath()).thenReturn(UNKNOWN_PATH);
+
         assertThatThrownBy(() -> appRequestHandler.handle(request, metaDataContext))
                 .isExactlyInstanceOf(PrimingNotFoundException.class)
-                .hasFieldOrPropertyWithValue("request", appRequest);
+                .hasFieldOrPropertyWithValue("request", new AppRequest(GET_METHOD, UNKNOWN_PATH));
     }
 
     @Test
-    void handleAddsRequestToFailedRequestsIfPrimingIsNotFound() throws Exception {
-        try{
+    void handleAddsRequestToFailedRequestsIfPrimingIsNotFound() {
+        when(request.getPath()).thenReturn(UNKNOWN_PATH);
+
+        try {
             appRequestHandler.handle(request, metaDataContext);
-        } catch (Exception e) {
-            verify(failedRequests).add(appRequest);
-        }
+        } catch (Exception ignored) { }
+
+        assertThat(failedRequests.getValues().get(0)).isEqualTo(new AppRequest(GET_METHOD, UNKNOWN_PATH));
+    }
+
+    @Test
+    void populateMetaDataWithEndpointRequestCount() {
+        appRequestHandler.handle(request, metaDataContext);
+
+        assertThat(metaDataContext.getContext().get(ENDPOINT_REQUEST_COUNT.toString())).isEqualTo(1);
+    }
+
+    @Test
+    void populateMetaDataWithPersistedEndpointRequestCount() {
+        appRequestHandler.handle(request, metaDataContext);
+
+        assertThat(metaDataContext.getContext().get(ENDPOINT_REQUEST_PERSISTENT_COUNT.toString())).isEqualTo(1);
     }
 }

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/AppRequestHandlerTest.java
@@ -72,7 +72,7 @@ class AppRequestHandlerTest {
                 .thenReturn(of(appResponse));
         appRequestHandler.handle(request);
 
-        verify(callHistory).add(exchange);
+        verify(callHistory).add(appRequest, exchange);
     }
 
     @Test

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandlerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/requests/ZombieRequestHandlerTest.java
@@ -97,9 +97,9 @@ class ZombieRequestHandlerTest {
         exchange3 = new Exchange(request3, response);
 
         callHistory = new CallHistory(100);
-        callHistory.add(exchange1);
-        callHistory.add(exchange2);
-        callHistory.add(exchange3);
+        callHistory.add(request1, exchange1);
+        callHistory.add(request2, exchange2);
+        callHistory.add(request3, exchange3);
 
         failedRequests = new FixedCapacityCache<>(100);
         failedRequests.add(appRequests.get(0));
@@ -219,7 +219,7 @@ class ZombieRequestHandlerTest {
 
         final Response got = zombieRequestHandler.handle(request);
 
-        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory));
+        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory.getValues()));
     }
 
     @Test
@@ -258,7 +258,7 @@ class ZombieRequestHandlerTest {
 
         final Response got = zombieRequestHandler.handle(request);
 
-        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory));
+        assertThat(got).isEqualTo(new ZombieResponse(OK_200, callHistory.getValues()));
     }
 
     @Test

--- a/jzonbie/src/test/java/com/jonnymatts/jzonbie/templating/ResponseTransformerTest.java
+++ b/jzonbie/src/test/java/com/jonnymatts/jzonbie/templating/ResponseTransformerTest.java
@@ -1,14 +1,16 @@
 package com.jonnymatts.jzonbie.templating;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.jonnymatts.jzonbie.Response;
+import com.jonnymatts.jzonbie.jackson.JzonbieObjectMapper;
+import com.jonnymatts.jzonbie.metadata.MetaDataContext;
+import com.jonnymatts.jzonbie.responses.AppResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.Map;
-
-import static java.util.Collections.singletonMap;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.lenient;
@@ -16,43 +18,63 @@ import static org.mockito.Mockito.lenient;
 @ExtendWith(MockitoExtension.class)
 class ResponseTransformerTest {
 
-    @Mock(answer = RETURNS_DEEP_STUBS) private TransformationContext transformationContext;
+    @Mock(answer = RETURNS_DEEP_STUBS) private MetaDataContext metaDataContext;
+    @Mock private MetaDataContext.RequestContext requestContext;
 
     private ResponseTransformer underTest;
 
     @BeforeEach
     void setUp() throws Exception {
-        lenient().when(transformationContext.getRequest().getUrl()).thenReturn("url");
-        lenient().when(transformationContext.getRequest().getMethod()).thenReturn("method");
+        lenient().when(metaDataContext.getContext().get("request")).thenReturn(requestContext);
+        lenient().when(requestContext.getMethod()).thenReturn("method");
+        lenient().when(requestContext.getUrl()).thenReturn("url");
 
-        underTest = new ResponseTransformer(new JzonbieHandlebars());
+        underTest = new ResponseTransformer(new JzonbieObjectMapper(), new JzonbieHandlebars());
     }
 
     @Test
-    void transformHeadersReturnsTransformedBody() {
-        final Map<String, String> got = underTest.transformHeaders(transformationContext, singletonMap("header", "{{ request.method }}"));
+    void doNothingIfNotTemplated() throws JsonProcessingException {
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.withHeader("header", "{{ request.method }}");
+        appResponse.withBody("");
+        Response got = underTest.transform(metaDataContext, appResponse);
+        assertThat(got.getHeaders()).containsExactly(entry("header", "{{ request.method }}"));
+    }
 
-        assertThat(got).containsExactly(
-                entry("header", "method")
-        );
+    @Test
+    void templatedHeadersReturnsTransformedHeaders() throws JsonProcessingException {
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.withHeader("header", "{{ request.method }}");
+        appResponse.withBody("");
+        appResponse.templated();
+        Response got = underTest.transform(metaDataContext, appResponse);
+        assertThat(got.getHeaders()).containsExactly(entry("header", "method"));
     }
 
     @Test
     void transformHeadersThrowsExceptionIfHandlebarsThrowsException() {
-        assertThatThrownBy(() -> underTest.transformHeaders(transformationContext, singletonMap("header", null)))
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.templated();
+        appResponse.withHeader("header", null);
+        assertThatThrownBy(() -> underTest.transform(metaDataContext, appResponse))
                 .isInstanceOf(TransformResponseException.class);
     }
 
     @Test
-    void transformBodyReturnsTransformedBody() {
-        final String got = underTest.transformBody(transformationContext, "{{ request.url }}");
+    void transformBodyReturnsTransformedBody() throws JsonProcessingException {
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.templated();
+        appResponse.withBody("{{ request.url }}");
+        final Response got = underTest.transform(metaDataContext, appResponse);
 
-        assertThat(got).isEqualTo("url");
+        assertThat(((String)got.getBody().getContent())).isEqualTo("url");
     }
 
     @Test
     void transformBodyThrowsExceptionIfHandlebarsThrowsException() {
-        assertThatThrownBy(() -> underTest.transformBody(transformationContext, null))
+        AppResponse appResponse = new AppResponse(200);
+        appResponse.templated();
+        assertThatThrownBy(() -> underTest.transform(metaDataContext, appResponse))
                 .isInstanceOf(TransformResponseException.class);
     }
 }


### PR DESCRIPTION
- Split out priming context a bit to give more seperation of concerns.
- Fixed count to no longer rely on the size of the internal list, so there is no longer an upper limit on the count number
- Made this count templatable via MetaDataTag ENDPOINT_REQUEST_COUNT
- Added home folder configuration, which will by default be added to home directory. Folder is called .jzonbie
- SSL generated jks no longer is put into tmp but .jzonbie/ssl/jzonbie.jks
- Added file persistence of endpoint counts, sits along side current count fucntionality
- New persistent request count is templatable via MetadataTag ENDPOINT_REQUEST_PERSISTENT_COUNT